### PR TITLE
minor cleanup (has breaking change)

### DIFF
--- a/strat/cmd/cmd.go
+++ b/strat/cmd/cmd.go
@@ -171,7 +171,7 @@ func runScript(name, wd string, args []string, ignoreNotExist, stdin bool) error
 		if ignoreNotExist {
 			return nil
 		}
-		return fmt.Errorf("Project doesn't have a %q script.\n", name)
+		return fmt.Errorf("project doesn't have a %q script", name)
 	}
 
 	if len(args) > 0 {

--- a/strat/cmd/update.go
+++ b/strat/cmd/update.go
@@ -167,10 +167,10 @@ func updateCLI() error {
 	}
 	defer zrc.Close()
 	if binZF == nil {
-		return fmt.Errorf("Could not find binary in %q.\n", *asset.Name)
+		return fmt.Errorf("could not find binary in %q", *asset.Name)
 	}
 	if sigZF == nil {
-		return fmt.Errorf("Could not find signature in %q.\n", *asset.Name)
+		return fmt.Errorf("could not find signature in %q", *asset.Name)
 	}
 
 	// Get the current binary path.
@@ -200,7 +200,7 @@ func updateCLI() error {
 	// Check the signature.
 	fmt.Println("  * Verifying cryptographic signature...")
 	if err := checkSig(binPath, sigPath); err != nil {
-		return fmt.Errorf("Failed to verify signature: %s.\n", err)
+		return fmt.Errorf("failed to verify signature: %s", err)
 	}
 
 	fmt.Println("  * Updating binary...")

--- a/tmpop/query.go
+++ b/tmpop/query.go
@@ -8,6 +8,15 @@ package tmpop
 
 import "encoding/json"
 
+// Query types.
+const (
+	GetInfo       = "GetInfo"
+	GetSegment    = "GetSegment"
+	FindSegments  = "FindSegments"
+	GetMapIDs     = "GetMapIDs"
+	DeleteSegment = "DeleteSegment"
+)
+
 // Query is the type used to query the tendermint App
 type Query struct {
 	Name string `json:"Name"`

--- a/tmpop/tmpop_test.go
+++ b/tmpop/tmpop_test.go
@@ -143,7 +143,7 @@ func TestQuery(t *testing.T) {
 		a.MockGetInfo.Fn = func() (interface{}, error) { return &filestore.Info{Name: fakeName}, nil }
 
 		info := &Info{}
-		err := h.makeQuery("GetInfo", nil, info)
+		err := h.makeQuery(GetInfo, nil, info)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -167,7 +167,7 @@ func TestQuery(t *testing.T) {
 		}
 
 		got := &cs.Segment{}
-		err := h.makeQuery("GetSegment", segment.GetLinkHash(), got)
+		err := h.makeQuery(GetSegment, segment.GetLinkHash(), got)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -194,7 +194,7 @@ func TestQuery(t *testing.T) {
 			Tags:         segment.Link.GetTags(),
 		}
 		got := make(cs.SegmentSlice, 0)
-		err := h.makeQuery("FindSegments", args, &got)
+		err := h.makeQuery(FindSegments, args, &got)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -221,7 +221,7 @@ func TestQuery(t *testing.T) {
 		}
 
 		var got []string
-		err := h.makeQuery("GetMapIDs", args, &got)
+		err := h.makeQuery(GetMapIDs, args, &got)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/tmstore/tmstore.go
+++ b/tmstore/tmstore.go
@@ -9,14 +9,9 @@
 package tmstore
 
 import (
-	"errors"
-
 	"encoding/json"
-
-	log "github.com/Sirupsen/logrus"
-
+	"errors"
 	"fmt"
-
 	"time"
 
 	"github.com/stratumn/sdk/cs"
@@ -24,9 +19,12 @@ import (
 	"github.com/stratumn/sdk/tmpop"
 	"github.com/stratumn/sdk/types"
 	"github.com/stratumn/sdk/utils"
+
 	wire "github.com/tendermint/go-wire"
 	ctypes "github.com/tendermint/tendermint/rpc/core/types"
 	tmtypes "github.com/tendermint/tendermint/types"
+
+	log "github.com/Sirupsen/logrus"
 )
 
 const (
@@ -176,7 +174,7 @@ func (t *TMStore) AddDidSaveChannel(saveChan chan *cs.Segment) {
 // GetInfo implements github.com/stratumn/sdk/store.Adapter.GetInfo.
 func (t *TMStore) GetInfo() (interface{}, error) {
 	info := &tmpop.Info{}
-	err := t.sendQuery("GetInfo", nil, info)
+	err := t.sendQuery(tmpop.GetInfo, nil, info)
 
 	return &Info{
 		Name:        Name,
@@ -204,7 +202,7 @@ func (t *TMStore) SaveSegment(segment *cs.Segment) error {
 // GetSegment implements github.com/stratumn/sdk/store.Adapter.GetSegment.
 func (t *TMStore) GetSegment(linkHash *types.Bytes32) (segment *cs.Segment, err error) {
 	segment = &cs.Segment{}
-	err = t.sendQuery("GetSegment", linkHash, segment)
+	err = t.sendQuery(tmpop.GetSegment, linkHash, segment)
 
 	// Return nil when no segment has been found (and not an empty segment)
 	if segment.IsEmpty() {
@@ -216,7 +214,7 @@ func (t *TMStore) GetSegment(linkHash *types.Bytes32) (segment *cs.Segment, err 
 // DeleteSegment implements github.com/stratumn/sdk/store.Adapter.DeleteSegment.
 func (t *TMStore) DeleteSegment(linkHash *types.Bytes32) (segment *cs.Segment, err error) {
 	segment = &cs.Segment{}
-	err = t.sendQuery("DeleteSegment", linkHash, segment)
+	err = t.sendQuery(tmpop.DeleteSegment, linkHash, segment)
 
 	// Return nil when no segment has been deleted (and not an empty segment)
 	if segment.IsEmpty() {
@@ -228,14 +226,14 @@ func (t *TMStore) DeleteSegment(linkHash *types.Bytes32) (segment *cs.Segment, e
 // FindSegments implements github.com/stratumn/sdk/store.Adapter.FindSegments.
 func (t *TMStore) FindSegments(filter *store.Filter) (segmentSlice cs.SegmentSlice, err error) {
 	segmentSlice = make(cs.SegmentSlice, 0)
-	err = t.sendQuery("FindSegments", filter, &segmentSlice)
+	err = t.sendQuery(tmpop.FindSegments, filter, &segmentSlice)
 	return
 }
 
 // GetMapIDs implements github.com/stratumn/sdk/store.Adapter.GetMapIDs.
 func (t *TMStore) GetMapIDs(pagination *store.Pagination) (ids []string, err error) {
 	ids = make([]string, 0)
-	err = t.sendQuery("GetMapIDs", pagination, &ids)
+	err = t.sendQuery(tmpop.GetMapIDs, pagination, &ids)
 	return
 }
 


### PR DESCRIPTION
* tmstore/tmpop: Minor cleanup (changing strings to constants, etc...)
* tmpop(breaking): tmstore uses binary for the link hash instead of strings
* fix lint errors