### PR TITLE
cs: add `Link.GetTagMap()`

### DIFF
--- a/cs/cs.go
+++ b/cs/cs.go
@@ -132,6 +132,18 @@ func (l *Link) GetTags() []string {
 	return nil
 }
 
+// GetTagMap returns the tags as a map of string to empty structs (a set).
+// It assumes the link is valid.
+func (l *Link) GetTagMap() map[string]struct{} {
+	tags := map[string]struct{}{}
+	if t, ok := l.Meta["tags"].([]interface{}); ok {
+		for _, v := range t {
+			tags[v.(string)] = struct{}{}
+		}
+	}
+	return tags
+}
+
 // SegmentSlice is a slice of segment pointers.
 type SegmentSlice []*Segment
 

--- a/cs/cs_test.go
+++ b/cs/cs_test.go
@@ -283,3 +283,18 @@ func TestLinkGetTags_nil(t *testing.T) {
 		t.Errorf("s.Link.GetTags() = %q want nil", got)
 	}
 }
+
+func TestLinkGetTagMap(t *testing.T) {
+	s := cstesting.RandomSegment()
+	s.Link.Meta["tags"] = []interface{}{"one", "two"}
+	tags := s.Link.GetTagMap()
+	if _, got := tags["one"]; !got {
+		t.Errorf(`tags["one"] = %v want %v`, got, true)
+	}
+	if _, got := tags["two"]; !got {
+		t.Errorf(`tags["two"] = %v want %v`, got, true)
+	}
+	if _, got := tags["three"]; got {
+		t.Errorf(`tags["three"] = %v want %v`, got, false)
+	}
+}

--- a/dummystore/dummystore.go
+++ b/dummystore/dummystore.go
@@ -199,15 +199,11 @@ HASH_LOOP:
 		}
 
 		if len(filter.Tags) > 0 {
-			tags := segment.Link.GetTags()
-			if len(tags) > 0 {
-				for _, tag := range filter.Tags {
-					if !containsString(tags, tag) {
-						continue HASH_LOOP
-					}
+			tags := segment.Link.GetTagMap()
+			for _, tag := range filter.Tags {
+				if _, ok := tags[tag]; !ok {
+					continue HASH_LOOP
 				}
-			} else {
-				continue HASH_LOOP
 			}
 		}
 
@@ -217,13 +213,4 @@ HASH_LOOP:
 	sort.Sort(segments)
 
 	return filter.Pagination.PaginateSegments(segments), nil
-}
-
-func containsString(a []string, s string) bool {
-	for _, v := range a {
-		if v == s {
-			return true
-		}
-	}
-	return false
 }

--- a/filestore/filestore.go
+++ b/filestore/filestore.go
@@ -163,15 +163,11 @@ func (a *FileStore) FindSegments(filter *store.Filter) (cs.SegmentSlice, error) 
 		}
 
 		if len(filter.Tags) > 0 {
-			tags := segment.Link.GetTags()
-			if len(tags) > 0 {
-				for _, tag := range filter.Tags {
-					if !containsString(tags, tag) {
-						return nil
-					}
+			tags := segment.Link.GetTagMap()
+			for _, tag := range filter.Tags {
+				if _, ok := tags[tag]; !ok {
+					return nil
 				}
-			} else {
-				return nil
 			}
 		}
 
@@ -258,14 +254,4 @@ func (a *FileStore) forEach(fn func(*cs.Segment) error) error {
 	}
 
 	return nil
-}
-
-func containsString(a []string, s string) bool {
-	for _, v := range a {
-		if v == s {
-			return true
-		}
-	}
-
-	return false
 }


### PR DESCRIPTION
Update `dummystore` and `filestore` so they no longer need the `ContainsString()` method.