### PR TITLE
Trim local $GOPATH from generated binaries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ GITHUB_RELEASE_FLAGS=--user '$(GITHUB_USER)' --repo '$(GITHUB_REPO)' --tag '$(GI
 GITHUB_RELEASE_RELEASE_FLAGS=$(GITHUB_RELEASE_FLAGS) --name '$(RELEASE_NAME)' --description "$$(cat $(RELEASE_NOTES_FILE))"
 
 GO_LIST=$(GO_CMD) list
-GO_BUILD=$(GO_CMD) build -ldflags '-X main.version=$(VERSION) -X main.commit=$(GIT_COMMIT)'
+GO_BUILD=$(GO_CMD) build -gcflags=-trimpath=$(GOPATH) -asmflags=-trimpath=$(GOPATH) -ldflags '-X main.version=$(VERSION) -X main.commit=$(GIT_COMMIT)'
 GO_TEST=$(GO_CMD) test
 GO_BENCHMARK=$(GO_TEST) -bench .
 GO_LINT=$(GO_LINT_CMD) -set_exit_status


### PR DESCRIPTION
It prevents Stack Traces from showing the developer local $GOPATH
- Before:
```
panic: BLAH

goroutine 1 [running]:
main.main()
    /Users/adrien/workspace/go/src/github.com/stratumn/sdk/cmd/filetmpop/main.go:27
    +0x64
```

- After:
```
panic: BLAH

goroutine 1 [running]:
main.main()
  src/github.com/stratumn/sdk/cmd/filetmpop/main.go:27
  +0x64
```