### PR TITLE
travis: run make lint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,12 @@ go:
   - 1.8
   - tip
 
+install:
+  - go get -u github.com/golang/lint/golint
+
 script:
   - make coverage
+  - make lint
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
Makes Travis install `golint` and run `make lint` after the tests.