### PR TITLE
code quality: predictable goroutines

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,14 @@
 language: go
 
 go:
-  - 1.8
+  - 1.8.1
   - tip
 
 install:
   - go get -u github.com/golang/lint/golint
 
 script:
-  - make coverage
-  - make lint
+  - make coverage && make lint
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/cmd/dummyfossilizer/doc.go
+++ b/cmd/dummyfossilizer/doc.go
@@ -13,17 +13,25 @@
 //	  -callbacktimeout duration
 //	    	callback requests timeout (default 10s)
 //	  -http string
-//	    	http address (default ":6000")
+//	    	HTTP address (default ":6000")
 //	  -maxdata int
 //	    	maximum data length (default 64)
+//	  -maxheaderbytes int
+//	    	maximum header bytes (default 256)
 //	  -mindata int
 //	    	minimum data length (default 32)
+//	  -readtimeout duration
+//	    	read timeout (default 10s)
+//	  -shutdowntimeout duration
+//	    	shutdown timeout (default 10s)
 //	  -tlscert string
 //	    	TLS certificate file
 //	  -tlskey string
 //	    	TLS private key file
 //	  -workers int
 //	    	number of result workers (default 8)
+//	  -writetimeout duration
+//	    	write timeout (default 10s)
 //
 // Docker
 //

--- a/cmd/dummystore/doc.go
+++ b/cmd/dummystore/doc.go
@@ -10,14 +10,24 @@
 //
 //	$ dummystore -h
 //	Usage of dummystore:
+//	  -didsavechansize int
+//	    	Size of the DidSave channel (default 256)
 //	  -http string
 //	    	HTTP address (default ":5000")
+//	  -maxheaderbytes int
+//	    	maximum header bytes (default 256)
 //	  -maxmsgsize int
 //	    	Maximum size of a received web socket message (default 32768)
+//	  -readtimeout duration
+//	    	read timeout (default 10s)
+//	  -shutdowntimeout duration
+//	    	shutdown timeout (default 10s)
 //	  -tlscert string
 //	    	TLS certificate file
 //	  -tlskey string
 //	    	TLS private key file
+//	  -writetimeout duration
+//	    	write timeout (default 10s)
 //	  -wspinginterval duration
 //	    	Interval between web socket pings (default 54s)
 //	  -wspongtimeout duration

--- a/cmd/dummystore/main.go
+++ b/cmd/dummystore/main.go
@@ -8,6 +8,7 @@ package main
 
 import (
 	"flag"
+	"time"
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/stratumn/sdk/dummystore"
@@ -17,6 +18,7 @@ import (
 )
 
 var (
+	didSaveChanSize = flag.Int("didsavechansize", storehttp.DefaultDidSaveChanSize, "Size of the DidSave channel")
 	http            = flag.String("http", storehttp.DefaultAddress, "HTTP address")
 	wsReadBufSize   = flag.Int("wsreadbufsize", storehttp.DefaultWebSocketReadBufferSize, "Web socket read buffer size")
 	wsWriteBufSize  = flag.Int("wswritebufsize", storehttp.DefaultWebSocketWriteBufferSize, "Web socket write buffer size")
@@ -27,6 +29,10 @@ var (
 	wsMaxMsgSize    = flag.Int64("maxmsgsize", storehttp.DefaultWebSocketMaxMsgSize, "Maximum size of a received web socket message")
 	certFile        = flag.String("tlscert", "", "TLS certificate file")
 	keyFile         = flag.String("tlskey", "", "TLS private key file")
+	readTimeout     = flag.Duration("readtimeout", jsonhttp.DefaultReadTimeout, "read timeout")
+	writeTimeout    = flag.Duration("writetimeout", jsonhttp.DefaultWriteTimeout, "write timeout")
+	maxHeaderBytes  = flag.Int("maxheaderbytes", jsonhttp.DefaultMaxHeaderBytes, "maximum header bytes")
+	shutdownTimeout = flag.Duration("shutdowntimeout", 10*time.Second, "shutdown timeout")
 	version         = "0.1.0"
 	commit          = "00000000000000000000000000000000"
 )
@@ -37,10 +43,16 @@ func main() {
 
 	a := dummystore.New(&dummystore.Config{Version: version, Commit: commit})
 
+	config := &storehttp.Config{
+		DidSaveChanSize: *didSaveChanSize,
+	}
 	httpConfig := &jsonhttp.Config{
-		Address:  *http,
-		CertFile: *certFile,
-		KeyFile:  *keyFile,
+		Address:        *http,
+		ReadTimeout:    *readTimeout,
+		WriteTimeout:   *writeTimeout,
+		MaxHeaderBytes: *maxHeaderBytes,
+		CertFile:       *certFile,
+		KeyFile:        *keyFile,
 	}
 	basicConfig := &jsonws.BasicConfig{
 		ReadBufferSize:  *wsReadBufSize,
@@ -53,5 +65,12 @@ func main() {
 		PingInterval: *wsPingInterval,
 		MaxMsgSize:   *wsMaxMsgSize,
 	}
-	storehttp.Run(a, httpConfig, basicConfig, bufConnConfig)
+	storehttp.Run(
+		a,
+		config,
+		httpConfig,
+		basicConfig,
+		bufConnConfig,
+		*shutdownTimeout,
+	)
 }

--- a/cmd/filestore/doc.go
+++ b/cmd/filestore/doc.go
@@ -10,16 +10,26 @@
 //
 //	$ filestore -h
 //	Usage of filestore:
+//	  -didsavechansize int
+//	    	Size of the DidSave channel (default 256)
 //	  -http string
 //	    	HTTP address (default ":5000")
+//	  -maxheaderbytes int
+//	    	maximum header bytes (default 256)
 //	  -maxmsgsize int
 //	    	Maximum size of a received web socket message (default 32768)
 //	  -path string
-//	      	path to directory where files are stored (default "/var/stratumn/filestore")
+//	    	path to directory where files are stored (default "/var/stratumn/filestore")
+//	  -readtimeout duration
+//	    	read timeout (default 10s)
+//	  -shutdowntimeout duration
+//	    	shutdown timeout (default 10s)
 //	  -tlscert string
 //	    	TLS certificate file
 //	  -tlskey string
 //	    	TLS private key file
+//	  -writetimeout duration
+//	    	write timeout (default 10s)
 //	  -wspinginterval duration
 //	    	Interval between web socket pings (default 54s)
 //	  -wspongtimeout duration

--- a/cmd/tmstore/doc.go
+++ b/cmd/tmstore/doc.go
@@ -10,18 +10,28 @@
 //
 //	$ tmstore -h
 //	Usage of tmstore:
+//	  -didsavechansize int
+//	    	Size of the DidSave channel (default 256)
 //	  -endpoint string
-//     		endpoint used to communicate with Tendermint Core (default "tcp://127.0.0.1:46657")
-//	  -tmWsRetryInterval duration
-//		interval between tendermint websocket connection tries (default 5s)
+//	    	Endpoint used to communicate with Tendermint Core (default "tcp://127.0.0.1:46657")
 //	  -http string
 //	    	HTTP address (default ":5000")
+//	  -maxheaderbytes int
+//	    	maximum header bytes (default 256)
 //	  -maxmsgsize int
 //	    	Maximum size of a received web socket message (default 32768)
+//	  -readtimeout duration
+//	    	read timeout (default 10s)
+//	  -shutdowntimeout duration
+//	    	shutdown timeout (default 10s)
 //	  -tlscert string
 //	    	TLS certificate file
 //	  -tlskey string
 //	    	TLS private key file
+//	  -tmwsretryinterval duration
+//	    	Interval between tendermint websocket connection tries (default 5s)
+//	  -writetimeout duration
+//	    	write timeout (default 10s)
 //	  -wspinginterval duration
 //	    	Interval between web socket pings (default 54s)
 //	  -wspongtimeout duration

--- a/cmd/tmstore/main.go
+++ b/cmd/tmstore/main.go
@@ -8,6 +8,7 @@ package main
 
 import (
 	"flag"
+	"time"
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/stratumn/sdk/jsonhttp"
@@ -17,6 +18,7 @@ import (
 )
 
 var (
+	didSaveChanSize   = flag.Int("didsavechansize", storehttp.DefaultDidSaveChanSize, "Size of the DidSave channel")
 	http              = flag.String("http", storehttp.DefaultAddress, "HTTP address")
 	wsReadBufSize     = flag.Int("wsreadbufsize", storehttp.DefaultWebSocketReadBufferSize, "Web socket read buffer size")
 	wsWriteBufSize    = flag.Int("wswritebufsize", storehttp.DefaultWebSocketWriteBufferSize, "Web socket write buffer size")
@@ -26,9 +28,13 @@ var (
 	wsPingInterval    = flag.Duration("wspinginterval", storehttp.DefaultWebSocketPingInterval, "Interval between web socket pings")
 	wsMaxMsgSize      = flag.Int64("maxmsgsize", storehttp.DefaultWebSocketMaxMsgSize, "Maximum size of a received web socket message")
 	endpoint          = flag.String("endpoint", tmstore.DefaultEndpoint, "Endpoint used to communicate with Tendermint Core")
-	tmWsRetryInterval = flag.Duration("tmWsRetryInterval", tmstore.DefaultWsRetryInterval, "Interval between tendermint websocket connection tries")
+	tmWsRetryInterval = flag.Duration("tmwsretryinterval", tmstore.DefaultWsRetryInterval, "Interval between tendermint websocket connection tries")
 	certFile          = flag.String("tlscert", "", "TLS certificate file")
 	keyFile           = flag.String("tlskey", "", "TLS private key file")
+	readTimeout       = flag.Duration("readtimeout", jsonhttp.DefaultReadTimeout, "read timeout")
+	writeTimeout      = flag.Duration("writetimeout", jsonhttp.DefaultWriteTimeout, "write timeout")
+	maxHeaderBytes    = flag.Int("maxheaderbytes", jsonhttp.DefaultMaxHeaderBytes, "maximum header bytes")
+	shutdownTimeout   = flag.Duration("shutdowntimeout", 10*time.Second, "shutdown timeout")
 	version           = "0.1.0"
 	commit            = "00000000000000000000000000000000"
 )
@@ -41,10 +47,16 @@ func main() {
 
 	go a.RetryStartWebsocket(*tmWsRetryInterval)
 
+	config := &storehttp.Config{
+		DidSaveChanSize: *didSaveChanSize,
+	}
 	httpConfig := &jsonhttp.Config{
-		Address:  *http,
-		CertFile: *certFile,
-		KeyFile:  *keyFile,
+		Address:        *http,
+		ReadTimeout:    *readTimeout,
+		WriteTimeout:   *writeTimeout,
+		MaxHeaderBytes: *maxHeaderBytes,
+		CertFile:       *certFile,
+		KeyFile:        *keyFile,
 	}
 	basicConfig := &jsonws.BasicConfig{
 		ReadBufferSize:  *wsReadBufSize,
@@ -57,5 +69,12 @@ func main() {
 		PingInterval: *wsPingInterval,
 		MaxMsgSize:   *wsMaxMsgSize,
 	}
-	storehttp.Run(a, httpConfig, basicConfig, bufConnConfig)
+	storehttp.Run(
+		a,
+		config,
+		httpConfig,
+		basicConfig,
+		bufConnConfig,
+		*shutdownTimeout,
+	)
 }

--- a/dummyfossilizer/dummyfossilizer.go
+++ b/dummyfossilizer/dummyfossilizer.go
@@ -79,11 +79,9 @@ func (a *DummyFossilizer) Fossilize(data []byte, meta []byte) error {
 		Meta: meta,
 	}
 
-	go func(chans []chan *fossilizer.Result) {
-		for _, c := range chans {
-			c <- r
-		}
-	}(a.resultChans)
+	for _, c := range a.resultChans {
+		c <- r
+	}
 
 	return nil
 }

--- a/dummystore/dummystore.go
+++ b/dummystore/dummystore.go
@@ -116,12 +116,9 @@ func (a *DummyStore) saveSegment(segment *cs.Segment) error {
 	a.segments[linkHashStr] = segment
 	a.maps[mapID][linkHashStr] = struct{}{}
 
-	// Send saved segment to all the save channels without blocking.
-	go func(chans []chan *cs.Segment) {
-		for _, c := range chans {
-			c <- segment
-		}
-	}(a.didSaveChans)
+	for _, c := range a.didSaveChans {
+		c <- segment
+	}
 
 	return nil
 }

--- a/filestore/filestore.go
+++ b/filestore/filestore.go
@@ -119,12 +119,9 @@ func (a *FileStore) saveSegment(segment *cs.Segment) error {
 		return err
 	}
 
-	// Send saved segment to all the save channels without blocking.
-	go func(chans []chan *cs.Segment) {
-		for _, c := range chans {
-			c <- segment
-		}
-	}(a.didSaveChans)
+	for _, c := range a.didSaveChans {
+		c <- segment
+	}
 
 	return nil
 }

--- a/fossilizer/fossilizerhttp/example_test.go
+++ b/fossilizer/fossilizerhttp/example_test.go
@@ -7,11 +7,13 @@
 package fossilizerhttp_test
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"log"
 	"net/http"
 	"net/http/httptest"
+	"time"
 
 	"github.com/stratumn/sdk/dummyfossilizer"
 	"github.com/stratumn/sdk/fossilizer/fossilizerhttp"
@@ -32,6 +34,10 @@ func Example() {
 
 	// Create a server.
 	s := fossilizerhttp.New(a, config, httpConfig)
+	go s.Start()
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer s.Shutdown(ctx)
+	defer cancel()
 
 	// Create a test server.
 	ts := httptest.NewServer(s)

--- a/fossilizer/fossilizerhttp/util_test.go
+++ b/fossilizer/fossilizerhttp/util_test.go
@@ -16,9 +16,12 @@ import (
 	"github.com/stratumn/sdk/jsonhttp"
 )
 
-func createServer() (*jsonhttp.Server, *fossilizertesting.MockAdapter) {
+func createServer() (*Server, *fossilizertesting.MockAdapter) {
 	a := &fossilizertesting.MockAdapter{}
-	s := New(a, &Config{MinDataLen: 2, MaxDataLen: 16}, &jsonhttp.Config{})
+	s := New(a, &Config{
+		MinDataLen: 2,
+		MaxDataLen: 16,
+	}, &jsonhttp.Config{})
 
 	return s, a
 }
@@ -27,6 +30,7 @@ type resultHandler struct {
 	t        *testing.T
 	listener net.Listener
 	want     string
+	done     chan struct{}
 }
 
 func (h *resultHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -43,4 +47,6 @@ func (h *resultHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if got, want := string(body), h.want; got != want {
 		h.t.Errorf("h.ServerHTTP(): body = %q want %q", got, want)
 	}
+
+	h.done <- struct{}{}
 }

--- a/store/storehttp/example_test.go
+++ b/store/storehttp/example_test.go
@@ -7,6 +7,7 @@
 package storehttp_test
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"log"
@@ -26,6 +27,9 @@ import (
 func Example() {
 	// Create a dummy adapter.
 	a := dummystore.New(&dummystore.Config{Version: "0.1.0", Commit: "abc"})
+	config := &storehttp.Config{
+		DidSaveChanSize: 8,
+	}
 	httpConfig := &jsonhttp.Config{
 		Address: "5555",
 	}
@@ -39,9 +43,11 @@ func Example() {
 	}
 
 	// Create a server.
-	s := storehttp.New(a, httpConfig, basicConfig, bufConnConfig)
+	s := storehttp.New(a, config, httpConfig, basicConfig, bufConnConfig)
 	go s.Start()
-	defer s.Shutdown()
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer s.Shutdown(ctx)
+	defer cancel()
 
 	// Create a test server.
 	ts := httptest.NewServer(s)

--- a/store/storehttp/storehttp_test.go
+++ b/store/storehttp/storehttp_test.go
@@ -7,6 +7,7 @@
 package storehttp
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -601,7 +602,7 @@ func TestGetSocket(t *testing.T) {
 		sendChan <- c
 	}
 
-	s := New(a, &jsonhttp.Config{}, &jsonws.BasicConfig{
+	s := New(a, &Config{}, &jsonhttp.Config{}, &jsonws.BasicConfig{
 		UpgradeHandle: upgradeHandle,
 	}, &jsonws.BufferedConnConfig{
 		Size:         256,
@@ -612,7 +613,9 @@ func TestGetSocket(t *testing.T) {
 	})
 
 	go s.Start()
-	defer s.Shutdown()
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer s.Shutdown(ctx)
+	defer cancel()
 
 	// Register web socket connection.
 	w := httptest.NewRecorder()

--- a/store/storehttp/util_test.go
+++ b/store/storehttp/util_test.go
@@ -16,7 +16,7 @@ import (
 
 func createServer() (*Server, *storetesting.MockAdapter) {
 	a := &storetesting.MockAdapter{}
-	s := New(a, &jsonhttp.Config{}, &jsonws.BasicConfig{}, &jsonws.BufferedConnConfig{
+	s := New(a, &Config{}, &jsonhttp.Config{}, &jsonws.BasicConfig{}, &jsonws.BufferedConnConfig{
 		Size:         256,
 		WriteTimeout: 10 * time.Second,
 		PongTimeout:  70 * time.Second,


### PR DESCRIPTION
* in most packages, routines will not return until child goroutines are finished
* cleaner fossilizerhttp server
* also using the go1.8 http.server.Shutdown() method to cleanly shutdown servers