### PR TITLE
Make tmpop run function reusable

### DIFF
--- a/cmd/filetmpop/main.go
+++ b/cmd/filetmpop/main.go
@@ -8,11 +8,9 @@ package main
 
 import (
 	"flag"
-	"runtime"
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/stratumn/sdk/filestore"
-	"github.com/stratumn/sdk/tendermint"
 	"github.com/stratumn/sdk/tmpop"
 )
 
@@ -31,22 +29,7 @@ func main() {
 		log.Fatal(err)
 	}
 
-	adapterInfo, err := a.GetInfo()
-	if err != nil {
-		log.Fatal(err)
-	}
-
 	tmpopConfig := &tmpop.Config{Commit: commit, Version: version, CacheSize: *cacheSize}
-	tmpop, err := tmpop.New(a, tmpopConfig)
-	if err != nil {
-		log.Fatal(err)
-	}
 
-	log.Infof("TMPop v%s@%s", tmpopConfig.Version, tmpopConfig.Commit[:7])
-	log.Infof("Adapter %v", adapterInfo)
-	log.Info("Copyright (c) 2017 Stratumn SAS")
-	log.Info("Mozilla Public License 2.0")
-	log.Infof("Runtime %s %s %s", runtime.Version(), runtime.GOOS, runtime.GOARCH)
-
-	tendermint.RunNodeForever(tendermint.GetConfig(), tmpop)
+	tmpop.Run(a, tmpopConfig)
 }


### PR DESCRIPTION
The current `tmpop.Run` function was a legacy from when we only launched the ABCI app independently.
Code from the cmd module has been moved to it so that it's reusable for each adapter.
