### PR TITLE
strat: change update mechanism

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -62,22 +62,16 @@ To launch tests, run within the project folder:
 $ strat test
 ```
 
-To update the CLI to the latest stable release, run: 
+To update the SDK to the latest stable release, run: 
 
 ```bash
 $ strat update
 ```
 
-To update the CLI to the latest prerelease, run: 
+To update the SDK to the latest prerelease, run: 
 
 ```bash
 $ strat update --prerelease
-```
-
-To update the generators, run: 
-
-```bash
-$ strat update --generators
 ```
 
 ### Configuration

--- a/strat/cmd/update.go
+++ b/strat/cmd/update.go
@@ -1,11 +1,11 @@
 // Copyright 2017 Stratumn SAS. All rights reserved.
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -38,29 +38,28 @@ import (
 var (
 	force      bool
 	prerelease bool
-	generators bool
 )
 
 // updateCmd represents the update command
 var updateCmd = &cobra.Command{
 	Use:   "update",
-	Short: "Update Stratumn CLI or generators",
-	Long: `Update Stratumn CLI or update generators to latest version.
+	Short: "Update Stratumn CLI and generators",
+	Long: `Update Stratumn CLI and update generators to latest version.
 
-It can download the latest version of the Stratumn CLI. It checks that the binary is cryptographically signed before installing. 
+It downloads the latest version of the Stratumn CLI if available. It checks that the binary is cryptographically signed before installing.
 
-It can also update generators using the --generators flag.	
+It will also update the generators if newer versions are available.	
 `,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if len(args) > 0 {
 			return errors.New("unexpected arguments")
 		}
 
-		if generators {
-			return updateGenerators()
+		if err := updateCLI(); err != nil {
+			return err
 		}
 
-		return updateCLI()
+		return updateGenerators()
 	},
 }
 
@@ -81,14 +80,6 @@ func init() {
 		"P",
 		false,
 		"Download prerelease version",
-	)
-
-	updateCmd.PersistentFlags().BoolVarP(
-		&generators,
-		"generators",
-		"g",
-		false,
-		"Update generators",
 	)
 }
 


### PR DESCRIPTION
`strat update` will now update both the CLI and generators.

In the future it would be nice to disable this feature if installed
via homebrew and recommend using `brew update && brew upgrade`
instead.

Closes #110.