### PR TITLE
validation: return bad request on validation error

### DIFF
--- a/store/storehttp/storehttp.go
+++ b/store/storehttp/storehttp.go
@@ -226,7 +226,7 @@ func (s *Server) saveSegment(w http.ResponseWriter, r *http.Request, _ httproute
 		return nil, jsonhttp.NewErrBadRequest("")
 	}
 	if err := seg.Validate(); err != nil {
-		return nil, jsonhttp.NewErrHTTP(err.Error(), http.StatusBadRequest)
+		return nil, jsonhttp.NewErrBadRequest(err.Error())
 	}
 	if err := s.adapter.SaveSegment(&seg); err != nil {
 		return nil, err

--- a/tmpop/testdata/rules.json
+++ b/tmpop/testdata/rules.json
@@ -1,0 +1,13 @@
+[
+    {
+        "type": "init",
+        "schema": {
+            "type": "object",
+            "properties": {
+                "string": {
+                    "type": "string"
+                }
+            }
+        }
+    }
+]

--- a/tmpop/tmpop.go
+++ b/tmpop/tmpop.go
@@ -77,14 +77,19 @@ type TMPop struct {
 }
 
 const (
-	// Name of the Tendermint Application
+	// Name of the Tendermint Application.
 	Name = "TMPop"
 
-	// Description of this Tendermint Application
+	// Description of this Tendermint Application.
 	Description = "Agent Store in a Blockchain"
 
-	// DefaultCacheSize is the default size of the DB cache
+	// DefaultCacheSize is the default size of the DB cache.
 	DefaultCacheSize = 0
+)
+
+const (
+	// CodeTypeValidation is the ABCI error code for a validation error.
+	CodeTypeValidation abci.CodeType = 400
 )
 
 // New creates a new instance of a TMPop.
@@ -379,7 +384,10 @@ func (t *TMPop) doTx(snapshot *Snapshot, txBytes []byte) (result abci.Result) {
 func (t *TMPop) checkSegment(snapshot *Snapshot, segment *cs.Segment) abci.Result {
 	err := segment.Validate()
 	if err != nil {
-		return abci.ErrUnauthorized.SetLog(fmt.Sprintf("Invalid segment %v: %v", segment, err))
+		return abci.NewError(
+			CodeTypeValidation,
+			fmt.Sprintf("Segment validation failed %v: %v", segment, err),
+		)
 	}
 
 	// TODO: in production do not reload validation rules each time a new segment is created
@@ -388,7 +396,10 @@ func (t *TMPop) checkSegment(snapshot *Snapshot, segment *cs.Segment) abci.Resul
 	err = rootValidator.Validate(snapshot.segments, segment)
 
 	if err != nil {
-		return abci.ErrUnauthorized.SetLog(fmt.Sprintf("Segment validation failed %v: %v", segment, err))
+		return abci.NewError(
+			CodeTypeValidation,
+			fmt.Sprintf("Segment validation failed %v: %v", segment, err),
+		)
 	}
 
 	return abci.OK

--- a/tmstore/testdata/rules.json
+++ b/tmstore/testdata/rules.json
@@ -1,0 +1,13 @@
+[
+    {
+        "type": "init",
+        "schema": {
+            "type": "object",
+            "properties": {
+                "string": {
+                    "type": "string"
+                }
+            }
+        }
+    }
+]

--- a/tmstore/tmstore.go
+++ b/tmstore/tmstore.go
@@ -34,6 +34,7 @@ import (
 	"github.com/tendermint/tmlibs/events"
 
 	log "github.com/Sirupsen/logrus"
+	"github.com/stratumn/sdk/jsonhttp"
 )
 
 const (
@@ -328,6 +329,11 @@ func (t *TMStore) broadcastTx(tx *tmpop.Tx) (*ctypes.ResultBroadcastTxCommit, er
 		return nil, err
 	}
 	if result.CheckTx.IsErr() {
+		if result.CheckTx.Code == tmpop.CodeTypeValidation {
+			// TODO: this package should be HTTP unaware, so
+			// we need a better way to pass error types.
+			return nil, jsonhttp.NewErrBadRequest(result.CheckTx.Error())
+		}
 		return nil, fmt.Errorf(result.CheckTx.Error())
 	}
 	if result.DeliverTx.IsErr() {

--- a/tmstore/util_test.go
+++ b/tmstore/util_test.go
@@ -7,6 +7,8 @@ of tests in various packages.
 **/
 
 import (
+	"path/filepath"
+
 	"github.com/stratumn/sdk/cs/cstesting"
 	"github.com/stratumn/sdk/dummystore"
 	"github.com/stratumn/sdk/tmpop"
@@ -36,7 +38,9 @@ func NewTestClient() *TMStore {
 func StartNode() *node.Node {
 	adapter := dummystore.New(&dummystore.Config{})
 	var err error
-	testTmpop, err = tmpop.New(adapter, &tmpop.Config{})
+	testTmpop, err = tmpop.New(adapter, &tmpop.Config{
+		ValidatorFilename: filepath.Join("testdata", "rules.json"),
+	})
 	if err != nil {
 		panic(err)
 	}

--- a/validator/root.go
+++ b/validator/root.go
@@ -75,11 +75,11 @@ func (rv *rootValidator) loadFromJSON(data []byte) error {
 	rv.Validators = make([]selectiveValidator, len(jsonStruct))
 	for i, val := range jsonStruct {
 		if val.Schema == nil {
-			return fmt.Errorf("loadFromJSON: schema missing for validator %s", val)
+			return fmt.Errorf("loadFromJSON: schema missing for validator %v", val)
 		}
 
 		if val.Type == "" {
-			return fmt.Errorf("loadFromJSON: type missing for validator %s", val)
+			return fmt.Errorf("loadFromJSON: type missing for validator %v", val)
 		}
 
 		schemaData, _ := val.Schema.MarshalJSON()

--- a/validator/schema.go
+++ b/validator/schema.go
@@ -27,7 +27,7 @@ func newSchemaValidator(segmentType string, data []byte) (*schemaValidator, erro
 }
 
 func (sv schemaValidator) Filter(_ store.Reader, segment *cs.Segment) bool {
-	// TODO: standartise action as string
+	// TODO: standardise action as string
 	segmentAction, ok := segment.Link.Meta["action"].(string)
 	if !ok {
 		log.Error("malformed segment")


### PR DESCRIPTION
The goal is to have agent-ui display the validation error properly.

The solution is not ideal. It could be improved by moving ErrHttp out
of the jsonhttp package and create a more generic error package with
HTTP status awareness.