### PR TITLE
strat: override default generator branch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ GITHUB_RELEASE_FLAGS=--user '$(GITHUB_USER)' --repo '$(GITHUB_REPO)' --tag '$(GI
 GITHUB_RELEASE_RELEASE_FLAGS=$(GITHUB_RELEASE_FLAGS) --name '$(RELEASE_NAME)' --description "$$(cat $(RELEASE_NOTES_FILE))"
 
 GO_LIST=$(GO_CMD) list
-GO_BUILD=$(GO_CMD) build -gcflags=-trimpath=$(GOPATH) -asmflags=-trimpath=$(GOPATH) -ldflags '-X main.version=$(VERSION) -X main.commit=$(GIT_COMMIT)'
+GO_BUILD=$(GO_CMD) build -gcflags=-trimpath=$(GOPATH) -asmflags=-trimpath=$(GOPATH) -ldflags '-X main.version=$(VERSION) -X main.commit=$(GIT_COMMIT) -X github.com/stratumn/sdk/strat/cmd.DefaultGeneratorsRef=$(GIT_TAG)'
 GO_TEST=$(GO_CMD) test
 GO_BENCHMARK=$(GO_TEST) -bench .
 GO_LINT=$(GO_LINT_CMD) -set_exit_status

--- a/strat/cmd/cmd.go
+++ b/strat/cmd/cmd.go
@@ -61,10 +61,6 @@ const (
 	// repository.
 	DefaultGeneratorsRepo = "generators"
 
-	// DefaultGeneratorsRef is the default reference of the generators'
-	// Github repository.
-	DefaultGeneratorsRef = "master"
-
 	// StratumnConfigEnv is the name of the environment variable to override
 	// the default configuration path.
 	StratumnConfigEnv = "STRATUMN_CONFIG"
@@ -112,6 +108,13 @@ const (
 
 	// DownTestScript is the name of the project down script for test.
 	DownTestScript = "down:test"
+)
+
+var (
+	// DefaultGeneratorsRef is the default reference of the generators'
+	// Github repository. It is a variable because it is overridden at
+	// compile time.
+	DefaultGeneratorsRef = "master"
 )
 
 const win = "windows"


### PR DESCRIPTION
This commit makes the Makefile override the default generator branch
used by strat. It uses the version tag as the name of the branch.

Closes #161.