### PR TITLE
strat: don't update CLI if installed via Homebrew

### DIFF
--- a/strat/cmd/cmd.go
+++ b/strat/cmd/cmd.go
@@ -117,11 +117,15 @@ var (
 	DefaultGeneratorsRef = "master"
 )
 
-const win = "windows"
+const (
+	win    = "windows"
+	darwin = "darwin"
+)
 
 var (
-	nixShell = []string{"sh", "-i", "-c"}
-	winShell = []string{"cmd", "/C"}
+	nixShell    = []string{"sh", "-i", "-c"}
+	winShell    = []string{"cmd", "/C"}
+	brewInfoCmd = []string{"brew", "info", "--json=v1", "stratumn/sdk/strat"}
 )
 
 // Project describes a project.


### PR DESCRIPTION
This commit will prevent `strat update` from updating the CLI if it
was installed via Homebrew. The behavior can be overridden using the
`--force` flag. It will still update the generators.

This is achieved by checking if a linked keg using `brew info` exists
and has the same version as the current `strat`.

Close #153.