### PR TITLE
validator: reduce log verbosity in validations

### DIFF
--- a/validator/root.go
+++ b/validator/root.go
@@ -92,7 +92,7 @@ func (rv *rootValidator) loadFromJSON(data []byte) error {
 		rv.Validators[i] = sv
 	}
 
-	log.Infof("validators loaded: %d", len(rv.Validators))
+	log.Debugf("validators loaded: %d", len(rv.Validators))
 
 	return nil
 }

--- a/validator/schema.go
+++ b/validator/schema.go
@@ -30,7 +30,7 @@ func (sv schemaValidator) Filter(_ store.Reader, segment *cs.Segment) bool {
 	// TODO: standardise action as string
 	segmentAction, ok := segment.Link.Meta["action"].(string)
 	if !ok {
-		log.Error("malformed segment")
+		log.Debug("No action found in segment %v", segment)
 		return false
 	}
 


### PR DESCRIPTION
We don't consider it as an error not to have an action string.
It may be perfectly valid. It just ain't validatable by the
schema validator.