### PR TITLE
ci: build and push docker image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,26 @@
+sudo: required
 language: go
-
+services:
+  - docker
 go:
   - 1.9
   - tip
-
+env:
+  global:
+  - COMMIT=${TRAVIS_COMMIT::8}
+  - DOCKER_USER=stratumndocker
 install:
   - go get -u github.com/golang/dep/cmd/dep
   - go get -u github.com/golang/lint/golint
   - dep ensure
-
 script:
   - make coverage && make lint
-
 after_success:
   - bash <(curl -s https://codecov.io/bash)
+deploy:
+  skip_cleanup: true
+  provider: script
+  script: docker login --username $DOCKER_USER --password $DOCKER_PASS && make build && make docker_images VERSION=$COMMIT && make docker_push VERSION=$COMMIT
+  on:
+    go: 1.9
+    branch: master

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+SHELL=/bin/bash
 NIX_OS_ARCHS?=darwin-amd64 linux-amd64
 WIN_OS_ARCHS?=windows-amd64
 DIST_DIR=dist


### PR DESCRIPTION
Build a docker image tagged with the commit hash (eg: `stratumn/filetmpop:32fe9d75`) after each successful build on master.
We could chose to push after each successful build on all branches. We'd just have to add:
```
all_branches: true
```
to the `on:` conditions
What do you think?