### PR TITLE
storehttp: use brackets for query string slices

### DIFF
--- a/store/storehttp/storehttp.go
+++ b/store/storehttp/storehttp.go
@@ -28,7 +28,7 @@
 //	DELETE /segments/:linkHash
 //		Deletes then renders a segment.
 //
-//	GET /segments?[offset=offset]&[limit=limit]&[mapId=mapId]&[prevLinkHash=prevLinkHash]&[tags=list+of+tags]
+//	GET /segments?[offset=offset]&[limit=limit]&[mapIds[]=id1]&[mapIds[]=id2]&[prevLinkHash=prevLinkHash]&[tags[]=tag1]&[tags[]=tag2]
 //		Finds and renders segments.
 //
 //	GET /maps?[offset=offset]&[limit=limit]

--- a/store/storehttp/storehttp_test.go
+++ b/store/storehttp/storehttp_test.go
@@ -329,7 +329,7 @@ func TestFindSegments(t *testing.T) {
 	a.MockFindSegments.Fn = func(*store.SegmentFilter) (cs.SegmentSlice, error) { return s1, nil }
 
 	var s2 cs.SegmentSlice
-	w, err := testutil.RequestJSON(s.ServeHTTP, "GET", "/segments?offset=1&limit=2&mapIds=123&prevLinkHash="+zeros+"&tags=one+two", nil, &s2)
+	w, err := testutil.RequestJSON(s.ServeHTTP, "GET", "/segments?offset=1&limit=2&mapIds%5B%5D=123&prevLinkHash="+zeros+"&tags%5B%5D=one&tags%5B%5D=two", nil, &s2)
 	if err != nil {
 		t.Fatalf("testutil.RequestJSON(): err: %s", err)
 	}
@@ -375,7 +375,7 @@ func TestFindSegments_multipleMapIDs(t *testing.T) {
 	a.MockFindSegments.Fn = func(*store.SegmentFilter) (cs.SegmentSlice, error) { return s1, nil }
 
 	var s2 cs.SegmentSlice
-	w, err := testutil.RequestJSON(s.ServeHTTP, "GET", "/segments?offset=1&limit=2&mapIds=123+456&prevLinkHash="+zeros+"&tags=one+two", nil, &s2)
+	w, err := testutil.RequestJSON(s.ServeHTTP, "GET", "/segments?offset=1&limit=2&mapIds[]=123&mapIds[]=456&prevLinkHash="+zeros+"&tags[]=one&tags%5B%5D=two", nil, &s2)
 	if err != nil {
 		t.Fatalf("testutil.RequestJSON(): err: %s", err)
 	}
@@ -423,7 +423,7 @@ func TestFindSegments_defaultLimit(t *testing.T) {
 	a.MockFindSegments.Fn = func(*store.SegmentFilter) (cs.SegmentSlice, error) { return s1, nil }
 
 	var s2 cs.SegmentSlice
-	w, err := testutil.RequestJSON(s.ServeHTTP, "GET", "/segments?offset=1&&mapIds=123&prevLinkHash="+zeros+"&tags=one+two", nil, &s2)
+	w, err := testutil.RequestJSON(s.ServeHTTP, "GET", "/segments?offset=1&&mapIds%5B%5D=123&prevLinkHash="+zeros+"&tags[]=one&tags[]=two", nil, &s2)
 	if err != nil {
 		t.Fatalf("testutil.RequestJSON(): err: %s", err)
 	}


### PR DESCRIPTION
Slices in query parameters must now use the empty brackets convention.

For example:

    GET /segments?mapIds[]=id1&mapIds[]=id2&tags[]=t1&tags[]=t2

It works whether the brackets are URL-encoded or not.

This is a breaking change, the old format is no longer supported.