### PR TITLE
strat: improve script execution

### DIFF
--- a/strat/cmd/build.go
+++ b/strat/cmd/build.go
@@ -24,7 +24,7 @@ var buildCmd = &cobra.Command{
 
 It executes, if present, the build command of the project.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return runScript(BuildScript, "", args, false, useStdin)
+		return runScript(BuildScript, "", args, false)
 	},
 }
 

--- a/strat/cmd/deploy.go
+++ b/strat/cmd/deploy.go
@@ -33,7 +33,7 @@ It executes, if present, the deploy:<env> command of the project.`,
 			return errors.New("expected environment")
 		}
 		script := fmt.Sprintf(DeployScriptFmt, args[0])
-		return runScript(script, "", args[1:], false, useStdin)
+		return runScript(script, "", args[1:], false)
 	},
 }
 

--- a/strat/cmd/down.go
+++ b/strat/cmd/down.go
@@ -24,7 +24,7 @@ var downCmd = &cobra.Command{
 
 It executes, if present, the down command of the project.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return runScript(DownScript, "", args, false, useStdin)
+		return runScript(DownScript, "", args, false)
 	},
 }
 

--- a/strat/cmd/generate.go
+++ b/strat/cmd/generate.go
@@ -119,7 +119,7 @@ It asks which generator to use, then uses that generator to generate a project i
 		}
 
 		if _, err := os.Stat(filepath.Join(out, ProjectFile)); err == nil {
-			if err = runScript(InitScript, out, nil, true, useStdin); err != nil {
+			if err = runScript(InitScript, out, nil, true); err != nil {
 				return err
 			}
 		} else if !os.IsNotExist(err) {

--- a/strat/cmd/pull.go
+++ b/strat/cmd/pull.go
@@ -24,7 +24,7 @@ var pullCmd = &cobra.Command{
 
 It executes, if present, the pull command of the project.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return runScript(PullScript, "", args, false, useStdin)
+		return runScript(PullScript, "", args, false)
 	},
 }
 

--- a/strat/cmd/push.go
+++ b/strat/cmd/push.go
@@ -24,7 +24,7 @@ var pushCmd = &cobra.Command{
 
 It executes, if present, the push command of the project.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return runScript(PushScript, "", args, false, useStdin)
+		return runScript(PushScript, "", args, false)
 	},
 }
 

--- a/strat/cmd/root.go
+++ b/strat/cmd/root.go
@@ -37,7 +37,6 @@ var (
 	generatorsRepo          string
 	generatorsRef           string
 	generatorsUseLocalFiles bool
-	useStdin                bool
 )
 
 // RootCmd represents the base command when called without any subcommands
@@ -118,13 +117,6 @@ func init() {
 		"generators-use-local-files",
 		false,
 		"Do not retrieve generators files from git",
-	)
-
-	RootCmd.PersistentFlags().BoolVar(
-		&useStdin,
-		"stdin",
-		true,
-		"Attach stdin to process when executing project commands",
 	)
 }
 

--- a/strat/cmd/run.go
+++ b/strat/cmd/run.go
@@ -31,7 +31,7 @@ It executes the given command of the project.`,
 		if len(args) < 1 {
 			return errors.New("expected command")
 		}
-		return runScript(args[0], "", args[1:], false, useStdin)
+		return runScript(args[0], "", args[1:], false)
 	},
 }
 

--- a/strat/cmd/test.go
+++ b/strat/cmd/test.go
@@ -24,8 +24,8 @@ var testCmd = &cobra.Command{
 
 It executes, if present, the test command of the project.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		testErr := runScript(TestScript, "", args, false, useStdin)
-		downErr := runScript(DownTestScript, "", nil, true, useStdin)
+		testErr := runScript(TestScript, "", args, false)
+		downErr := runScript(DownTestScript, "", nil, true)
 
 		if testErr != nil {
 			return testErr

--- a/strat/cmd/up.go
+++ b/strat/cmd/up.go
@@ -24,7 +24,7 @@ var upCmd = &cobra.Command{
 
 It executes, if present, the up command of the project.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return runScript(UpScript, "", args, false, useStdin)
+		return runScript(UpScript, "", args, false)
 	},
 }
 


### PR DESCRIPTION
Instead of using the `exec` package, running a script now calls
`syscall.exec` to execute the shell command. The difference is that
instead of launching a child process, the current process is replaced by
the shell process.

Running `strat up` still sometimes exits with a status of 2, but when a
script command fails, as a result of this change the `strat` usage message won't be
displayed. This is the expected behavior because a shell error is not a
usage error.