### PR TITLE
strat: fix working dir and remove `test:down` script

### DIFF
--- a/strat/cmd/cmd.go
+++ b/strat/cmd/cmd.go
@@ -168,7 +168,13 @@ func varsPath() string {
 }
 
 func runScript(name, wd string, args []string, ignoreNotExist bool) error {
-	prj, err := NewProjectFromFile(filepath.Join(wd, ProjectFile))
+	if wd != "" {
+		if err := os.Chdir(wd); err != nil {
+			return err
+		}
+	}
+
+	prj, err := NewProjectFromFile(ProjectFile)
 	if err != nil {
 		return err
 	}

--- a/strat/cmd/cmd.go
+++ b/strat/cmd/cmd.go
@@ -104,9 +104,6 @@ const (
 	// DeployScriptFmt is the format of the name of the project deploy
 	// script for an environment.
 	DeployScriptFmt = "deploy:%s"
-
-	// DownTestScript is the name of the project down script for test.
-	DownTestScript = "down:test"
 )
 
 var (

--- a/strat/cmd/test.go
+++ b/strat/cmd/test.go
@@ -24,14 +24,7 @@ var testCmd = &cobra.Command{
 
 It executes, if present, the test command of the project.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		testErr := runScript(TestScript, "", args, false)
-		downErr := runScript(DownTestScript, "", nil, true)
-
-		if testErr != nil {
-			return testErr
-		}
-
-		return downErr
+		return runScript(TestScript, "", args, false)
 	},
 }
 


### PR DESCRIPTION
I merged too quickly yesterday... I think it's time to write tests for `strat` :)

I had forgotten to set the working dir before launching the shell command, so `strat generate` would fail when trying to execute the `init` script of a project. 

Also since now the process is completely replaced by the shell script, it is impossible to call `runScript` more than once. The `strat test` command was calling two scripts (test and down:test). Now it will only call the `test` script, so we are going to have to figure out a way to do everything with a single test command in the generators.