### PR TITLE
tendermint: upgrade to version 0.11.1

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -194,10 +194,10 @@
   version = "v1.0.0"
 
 [[projects]]
+  branch = "master"
   name = "github.com/spf13/viper"
   packages = ["."]
-  revision = "25b30aa063fc18e48662b86996252eabdcf2f0c7"
-  version = "v1.0.0"
+  revision = "d9cca5ef33035202efb1586825bdbb15ff9ec3ba"
 
 [[projects]]
   branch = "master"
@@ -236,16 +236,16 @@
   revision = "2a93256d2c6fbcc3b55673c0d2b96a7e32c6238b"
 
 [[projects]]
-  branch = "develop"
   name = "github.com/tendermint/tendermint"
-  packages = ["blockchain","config","consensus","mempool","node","p2p","p2p/upnp","proxy","rpc/client","rpc/core","rpc/core/types","rpc/grpc","rpc/lib","rpc/lib/client","rpc/lib/server","rpc/lib/types","rpc/test","state","state/txindex","state/txindex/kv","state/txindex/null","types","version"]
-  revision = "382bead5482e8e379aea3bf7857cf8e28d6da850"
+  packages = ["blockchain","config","consensus","consensus/types","mempool","node","p2p","p2p/upnp","proxy","rpc/client","rpc/core","rpc/core/types","rpc/grpc","rpc/lib","rpc/lib/client","rpc/lib/server","rpc/lib/types","rpc/test","state","state/txindex","state/txindex/kv","state/txindex/null","types","version"]
+  revision = "d4634dc6832a7168c2536e7c71bfba4a8ca857be"
+  version = "v0.11.1"
 
 [[projects]]
   name = "github.com/tendermint/tmlibs"
   packages = ["autofile","cli/flags","clist","common","db","events","flowrate","log","merkle"]
-  revision = "9997e3a3b46db1d2f88aa9816ed0e7915dad6ac1"
-  version = "v0.3.1"
+  revision = "096dcb90e60aa00b748b3fe49a4b95e48ebf1e13"
+  version = "v0.3.2"
 
 [[projects]]
   branch = "master"
@@ -328,6 +328,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "a93398c940b360f9c68de5f85b0d244a6648397a682f90895550db5c17dce835"
+  inputs-digest = "de791a044dc3bcc7e86ac6f176d795a7688c4d9a26cf90e9983c08da380506a4"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -43,13 +43,12 @@
   version = "0.6.2"
 
 [[constraint]]
-  branch = "develop"
   name = "github.com/tendermint/tendermint"
-  #version = "0.11.0"
+  version = "0.11.1"
 
 [[constraint]]
   name = "github.com/tendermint/tmlibs"
-  version = "0.3.1"
+  version = "0.3.2"
 
 [[constraint]]
   branch = "master"


### PR DESCRIPTION
Awaited fixes:
- rpc: fixed client WebSocket timeout
- rpc: client now resubscribes on reconnection
- fix our tmstore unit tests crashing randomly on wal file writes