### PR TITLE
*: improve version computation from git

### DIFF
--- a/version.sh
+++ b/version.sh
@@ -34,8 +34,8 @@ if [ $generator_version -eq 1 ]; then
     exit 0
 fi
 
-current_tag=`git describe --tags`
-if git tag -l | grep "^$current_tag\$"; then
+current_tag=`git describe --tags --exact-match 2> /dev/null`
+if [ $? -eq 0 ]; then
     echo $current_tag
 else
     git branch | grep '^\*' | awk '{ print $2}'


### PR DESCRIPTION
New way is a bit simpler. We also want to prevent "No names found,
cannot describe anything" errors in travis logs.