### PR TITLE
jsonwstesting: fix bad string format

### DIFF
--- a/jsonws/jsonwstesting/mockconn_test.go
+++ b/jsonws/jsonwstesting/mockconn_test.go
@@ -133,7 +133,7 @@ func TestMockConn_SetReadDeadline(t *testing.T) {
 		t.Errorf("a.MockSetReadDeadline.CalledWith = %q want %q", got, want)
 	}
 	if got, want := a.MockSetReadDeadline.LastCalledWith, v; got != want {
-		t.Errorf("a.MockSetReadDeadline.LastCalledWith = %d want %d", got, want)
+		t.Errorf("a.MockSetReadDeadline.LastCalledWith = %v want %v", got, want)
 	}
 }
 
@@ -152,7 +152,7 @@ func TestMockConn_SetWriteDeadline(t *testing.T) {
 		t.Errorf("a.MockSetWriteDeadline.CalledWith = %q want %q", got, want)
 	}
 	if got, want := a.MockSetWriteDeadline.LastCalledWith, v; got != want {
-		t.Errorf("a.MockSetWriteDeadline.LastCalledWith = %d want %d", got, want)
+		t.Errorf("a.MockSetWriteDeadline.LastCalledWith = %v want %v", got, want)
 	}
 }
 


### PR DESCRIPTION
Using %d for time.Time is not allowed in go tip

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stratumn/sdk/227)
<!-- Reviewable:end -->
