### PR TITLE
ci: fix binary building for docker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ after_success:
 deploy:
   skip_cleanup: true
   provider: script
-  script: docker login --username $DOCKER_USER --password $DOCKER_PASS && make build && make docker_images VERSION=$COMMIT && make docker_push VERSION=$COMMIT
+  script: docker login --username $DOCKER_USER --password $DOCKER_PASS && CGO_ENABLED=0 make docker_images VERSION=$COMMIT && make docker_push VERSION=$COMMIT
   on:
     go: 1.9
     branch: master


### PR DESCRIPTION
CGO has to be explicitly disabled for our binaries to run on our docker images
that are "FROM scratch"

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stratumn/sdk/228)
<!-- Reviewable:end -->
