### PR TITLE
store: add linkHashes matching to segment match method

### DIFF
--- a/store/store.go
+++ b/store/store.go
@@ -183,12 +183,16 @@ func (filter SegmentFilter) Match(segment *cs.Segment) bool {
 	}
 
 	if len(filter.LinkHashes) > 0 {
+		var match bool
 		for _, linkHash := range filter.LinkHashes {
 			if linkHash.Compare(segment.GetLinkHash()) == 0 {
-				return true
+				match = true
+				break
 			}
 		}
-		return false
+		if !match {
+			return false
+		}
 	}
 
 	if filter.Process != "" && filter.Process != segment.Link.GetProcess() {

--- a/store/store.go
+++ b/store/store.go
@@ -110,6 +110,10 @@ type SegmentFilter struct {
 	// empty string is to search Segments without parent
 	PrevLinkHash *string `json:"prevLinkHash"`
 
+	// A slice of linkHashes to search Segments.
+	// This attribute is optional.
+	LinkHashes []*types.Bytes32 `json:"linkHashes"`
+
 	// A slice of tags the segments must all contain.
 	Tags []string `json:"tags"`
 }
@@ -176,6 +180,15 @@ func (filter SegmentFilter) Match(segment *cs.Segment) bool {
 				return false
 			}
 		}
+	}
+
+	if len(filter.LinkHashes) > 0 {
+		for _, linkHash := range filter.LinkHashes {
+			if linkHash.Compare(segment.GetLinkHash()) == 0 {
+				return true
+			}
+		}
+		return false
 	}
 
 	if filter.Process != "" && filter.Process != segment.Link.GetProcess() {

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/stratumn/sdk/cs/cstesting"
+	"github.com/stratumn/sdk/types"
 
 	"github.com/stratumn/sdk/cs"
 	"github.com/stratumn/sdk/testutil"
@@ -80,11 +81,14 @@ func TestSegmentFilter_Match(t *testing.T) {
 		MapIDs       []string
 		Process      string
 		PrevLinkHash *string
+		LinkHashes   []*types.Bytes32
 		Tags         []string
 	}
 	type args struct {
 		segment *cs.Segment
 	}
+	linkHashesSegment := defaultTestingSegment()
+	linkHashesSegmentHash := linkHashesSegment.GetLinkHash()
 	tests := []struct {
 		name   string
 		fields fields
@@ -158,6 +162,18 @@ func TestSegmentFilter_Match(t *testing.T) {
 			want:   false,
 		},
 		{
+			name:   "LinkHashes ok",
+			fields: fields{LinkHashes: []*types.Bytes32{testutil.RandomHash(), linkHashesSegmentHash}},
+			args:   args{linkHashesSegment},
+			want:   true,
+		},
+		{
+			name:   "LinkHashes ko",
+			fields: fields{LinkHashes: []*types.Bytes32{testutil.RandomHash()}},
+			args:   args{defaultTestingSegment()},
+			want:   false,
+		},
+		{
 			name:   "One tag",
 			fields: fields{Tags: []string{"Foo"}},
 			args:   args{defaultTestingSegment()},
@@ -188,6 +204,7 @@ func TestSegmentFilter_Match(t *testing.T) {
 				Pagination:   tt.fields.Pagination,
 				MapIDs:       tt.fields.MapIDs,
 				Process:      tt.fields.Process,
+				LinkHashes:   tt.fields.LinkHashes,
 				PrevLinkHash: tt.fields.PrevLinkHash,
 				Tags:         tt.fields.Tags,
 			}

--- a/store/storetestcases/findsegments.go
+++ b/store/storetestcases/findsegments.go
@@ -379,7 +379,7 @@ func (f Factory) TestFindSegmentsLinkHashesMultiMatch(t *testing.T) {
 	}
 }
 
-// TestFindSegmentsLinkHashesBadProcess tests matching a linkHash will fail
+// TestFindSegmentsLinkHashesWithProcess tests matching a linkHash will fail
 // if the provided process attribute does not match.
 func (f Factory) TestFindSegmentsLinkHashesWithProcess(t *testing.T) {
 	a := f.initAdapter(t)

--- a/store/storetestcases/findsegments.go
+++ b/store/storetestcases/findsegments.go
@@ -26,6 +26,7 @@ import (
 	"github.com/stratumn/sdk/cs/cstesting"
 	"github.com/stratumn/sdk/store"
 	"github.com/stratumn/sdk/testutil"
+	"github.com/stratumn/sdk/types"
 )
 
 var emptyPrevLinkHash = ""
@@ -347,7 +348,66 @@ func (f Factory) TestFindSegmentsMapIDNotFound(t *testing.T) {
 	}
 }
 
-// TestFindSegmentsEmptyPrevLinkHash tests whan happens when you search for an
+// TestFindSegmentsLinkHashesMultiMatch tests searching for segments by a slice of
+// linkHashes with multiple matches.
+func (f Factory) TestFindSegmentsLinkHashesMultiMatch(t *testing.T) {
+	a := f.initAdapter(t)
+	defer f.free(a)
+
+	segment1 := saveNewSegment(&a, nil)
+	segment2 := saveNewSegment(&a, nil)
+	for j := 0; j < store.DefaultLimit; j++ {
+		saveNewSegment(&a, nil)
+	}
+
+	slice, err := a.FindSegments(&store.SegmentFilter{
+		LinkHashes: []*types.Bytes32{
+			segment1.GetLinkHash(),
+			testutil.RandomHash(),
+			segment2.GetLinkHash(),
+		},
+	})
+	if err != nil {
+		t.Fatalf("a.FindSegments(): err: %s", err)
+	}
+
+	if got := slice; got == nil {
+		t.Fatal("slice = nit want cs.SegmentSlice")
+	}
+	if got, want := len(slice), 2; got != want {
+		t.Errorf("len(slice) = %d want %d", got, want)
+	}
+}
+
+// TestFindSegmentsLinkHashesNoMatch tests searching for segments by a slice of
+// linkHashes will return emtpy slice when there are no matches.
+func (f Factory) TestFindSegmentsLinkHashesNoMatch(t *testing.T) {
+	a := f.initAdapter(t)
+	defer f.free(a)
+
+	for j := 0; j < store.DefaultLimit; j++ {
+		saveNewSegment(&a, nil)
+	}
+
+	slice, err := a.FindSegments(&store.SegmentFilter{
+		LinkHashes: []*types.Bytes32{
+			testutil.RandomHash(),
+			testutil.RandomHash(),
+		},
+	})
+	if err != nil {
+		t.Fatalf("a.FindSegments(): err: %s", err)
+	}
+
+	if got := slice; got == nil {
+		t.Fatal("slice = nit want cs.SegmentSlice")
+	}
+	if got, want := len(slice), 0; got != want {
+		t.Errorf("len(slice) = %d want %d", got, want)
+	}
+}
+
+// TestFindSegmentsEmptyPrevLinkHash tests what happens when you search for an
 // existing previous link hash.
 func (f Factory) TestFindSegmentsEmptyPrevLinkHash(t *testing.T) {
 	a := f.initAdapter(t)

--- a/store/storetestcases/storetestcases.go
+++ b/store/storetestcases/storetestcases.go
@@ -69,6 +69,7 @@ func (f Factory) RunTests(t *testing.T) {
 	t.Run("FindSegmentsPrevLinkHashBadMapID", f.TestFindSegmentsPrevLinkHashBadMapID)
 	t.Run("FindSegmentsPrevLinkHashNotFound", f.TestFindSegmentsPrevLinkHashNotFound)
 	t.Run("FindSegmentsLinkHashesMultiMatch", f.TestFindSegmentsLinkHashesMultiMatch)
+	t.Run("FindSegmentsLinkHashesWithProcess", f.TestFindSegmentsLinkHashesWithProcess)
 	t.Run("FindSegmentsLinkHashesNoMatch", f.TestFindSegmentsLinkHashesNoMatch)
 	t.Run("TestFindSegmentWithGoodProcess", f.TestFindSegmentWithGoodProcess)
 	t.Run("TestFindSegmentWithBadProcess", f.TestFindSegmentWithBadProcess)

--- a/store/storetestcases/storetestcases.go
+++ b/store/storetestcases/storetestcases.go
@@ -68,6 +68,8 @@ func (f Factory) RunTests(t *testing.T) {
 	t.Run("FindSegmentsPrevLinkHashGoodMapID", f.TestFindSegmentsPrevLinkHashGoodMapID)
 	t.Run("FindSegmentsPrevLinkHashBadMapID", f.TestFindSegmentsPrevLinkHashBadMapID)
 	t.Run("FindSegmentsPrevLinkHashNotFound", f.TestFindSegmentsPrevLinkHashNotFound)
+	t.Run("FindSegmentsLinkHashesMultiMatch", f.TestFindSegmentsLinkHashesMultiMatch)
+	t.Run("FindSegmentsLinkHashesNoMatch", f.TestFindSegmentsLinkHashesNoMatch)
 	t.Run("TestFindSegmentWithGoodProcess", f.TestFindSegmentWithGoodProcess)
 	t.Run("TestFindSegmentWithBadProcess", f.TestFindSegmentWithBadProcess)
 	t.Run("GetInfo", f.TestGetInfo)


### PR DESCRIPTION
The segment match method now compares the segments linkHash to
the linkHashes slice in the segmentFilter if it is present to
determine a match.

I think this should be good to go I added some tests for the relevant parts. I was expecting to have to make more changes to get the add tests in `storetestcases/findsegments.go` to work, but I did not need to change anything more. 

#216

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stratumn/sdk/231)
<!-- Reviewable:end -->
