### PR TITLE
couchstore: remove segment validation

### DIFF
--- a/couchstore/couchstore.go
+++ b/couchstore/couchstore.go
@@ -101,10 +101,6 @@ func (c *CouchStore) AddDidSaveChannel(saveChan chan *cs.Segment) {
 
 // SaveSegment implements github.com/stratumn/sdk/store.Adapter.SaveSegment.
 func (c *CouchStore) SaveSegment(segment *cs.Segment) (err error) {
-	if err = segment.Validate(); err != nil {
-		return
-	}
-
 	if err := c.saveSegment(segment); err != nil {
 		return err
 	}


### PR DESCRIPTION
Removed validation from couchstore as it is already done at storehttp level.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stratumn/sdk/238)
<!-- Reviewable:end -->
