### PR TITLE
stores: define new store interfaces

### DIFF
--- a/store/store.go
+++ b/store/store.go
@@ -123,7 +123,7 @@ type EvidenceReader interface {
 // EvidenceWriter is the interface for adding evidence to a segment in a store.
 type EvidenceWriter interface {
 	// Add an evidence to a segment.
-	AddEvidence(linkHash *types.Bytes32, evidence *cs.Evidence) (*types.Bytes32, error)
+	AddEvidence(linkHash *types.Bytes32, evidence *cs.Evidence) error
 }
 
 // EvidenceStore is the interface for storing and reading segment evidence.

--- a/store/store.go
+++ b/store/store.go
@@ -137,7 +137,6 @@ type EvidenceStore interface {
 type BatchV2 interface {
 	SegmentReader
 	LinkWriter
-	EvidenceStore
 
 	// Write definitely writes the content of the Batch
 	Write() error

--- a/store/store.go
+++ b/store/store.go
@@ -142,20 +142,21 @@ type BatchV2 interface {
 	Write() error
 }
 
-// DidSaveEventType lets you know what kind of object was saved to the store.
-type DidSaveEventType int
+// EventType lets you know the kind of event received.
+// A client should ignore events it doesn't care about or doesn't understand.
+type EventType int
 
 const (
-	// Link means that a segment link was saved.
-	Link DidSaveEventType = iota
-	// Evidence means that a segment evidence was saved.
-	Evidence
+	// SavedLink means that a segment link was saved.
+	SavedLink EventType = iota
+	// SavedEvidence means that a segment evidence was saved.
+	SavedEvidence
 )
 
-// DidSaveEvent is the event sent to a channel to notify when objects are saved to the store.
-type DidSaveEvent struct {
-	Type  DidSaveEventType
-	Value interface{}
+// Event is the object stores send to notify of important events.
+type Event struct {
+	EventType EventType
+	Details   interface{}
 }
 
 // AdapterV2 is the new store interface. Once all stores are migrated
@@ -168,8 +169,8 @@ type AdapterV2 interface {
 	// Returns arbitrary information about the adapter.
 	GetInfo() (interface{}, error)
 
-	// Adds a channel that receives events whenever content is saved to the store.
-	AddDidSaveChannel(chan *DidSaveEvent)
+	// Adds a channel that receives events from the store.
+	AddStoreEventChannel(chan *Event)
 
 	// Creates a new Batch
 	NewBatch() (BatchV2, error)

--- a/store/store.go
+++ b/store/store.go
@@ -143,6 +143,22 @@ type BatchV2 interface {
 	Write() error
 }
 
+// DidSaveEventType lets you know what kind of object was saved to the store.
+type DidSaveEventType int
+
+const (
+	// Link means that a segment link was saved.
+	Link DidSaveEventType = iota
+	// Evidence means that a segment evidence was saved.
+	Evidence
+)
+
+// DidSaveEvent is the event sent to a channel to notify when objects are saved to the store.
+type DidSaveEvent struct {
+	Type  DidSaveEventType
+	Value interface{}
+}
+
 // AdapterV2 is the new store interface. Once all stores are migrated
 // it will be renamed to Adapter and the old interface will be removed.
 type AdapterV2 interface {
@@ -153,11 +169,8 @@ type AdapterV2 interface {
 	// Returns arbitrary information about the adapter.
 	GetInfo() (interface{}, error)
 
-	// Adds a channel that receives segment links whenever they are saved.
-	AddDidSaveLinkChannel(chan *cs.Link)
-
-	// Adds a channel that receives segment evidences whenever they are saved.
-	AddDidSaveEvidenceChannel(chan *cs.Evidence)
+	// Adds a channel that receives events whenever content is saved to the store.
+	AddDidSaveChannel(chan *DidSaveEvent)
 
 	// Creates a new Batch
 	NewBatch() (BatchV2, error)

--- a/store/store.go
+++ b/store/store.go
@@ -84,6 +84,105 @@ type Adapter interface {
 	NewBatch() (Batch, error)
 }
 
+/* Updated store interfaces.
+ * Existing stores should migrate to these interfaces.
+ * New stores should implement only this interface.
+ */
+
+// SegmentReader is the interface for reading Segments from a store.
+type SegmentReader interface {
+	// Get a segment by link hash. Returns nil if no match is found.
+	// Will return link and evidences (if there are some in that store).
+	GetSegment(linkHash *types.Bytes32) (*cs.Segment, error)
+
+	// Find segments. Returns an empty slice if there are no results.
+	// Will return links and evidences (if there are some).
+	FindSegments(filter *SegmentFilter) (cs.SegmentSlice, error)
+
+	// Get all the existing map IDs.
+	GetMapIDs(filter *MapFilter) ([]string, error)
+}
+
+// LinkWriter is the interface for writing links to a store.
+// Links are immutable and cannot be deleted.
+type LinkWriter interface {
+	// Create the immutable part of a segment.
+	// The input link is expected to be valid.
+	// Returns the link hash or an error.
+	CreateLink(link *cs.Link) (*types.Bytes32, error)
+}
+
+// EvidenceReader is the interface for reading segment evidence from a store.
+type EvidenceReader interface {
+	// Get the evidences for a segment.
+	// Can return a nil error with an empty evidence slice if
+	// the segment currently doesn't have evidence.
+	GetEvidences(linkHash *types.Bytes32) (*cs.Evidences, error)
+}
+
+// EvidenceWriter is the interface for adding evidence to a segment in a store.
+type EvidenceWriter interface {
+	// Add an evidence to a segment.
+	AddEvidence(linkHash *types.Bytes32, evidence *cs.Evidence) (*types.Bytes32, error)
+}
+
+// EvidenceStore is the interface for storing and reading segment evidence.
+type EvidenceStore interface {
+	EvidenceReader
+	EvidenceWriter
+}
+
+// BatchV2 represents a database transaction.
+// It will be renamed to Batch when the old interface will be removed.
+type BatchV2 interface {
+	SegmentReader
+	LinkWriter
+	EvidenceStore
+
+	// Write definitely writes the content of the Batch
+	Write() error
+}
+
+// AdapterV2 is the new store interface. Once all stores are migrated
+// it will be renamed to Adapter and the old interface will be removed.
+type AdapterV2 interface {
+	SegmentReader
+	LinkWriter
+	EvidenceStore
+
+	// Returns arbitrary information about the adapter.
+	GetInfo() (interface{}, error)
+
+	// Adds a channel that receives segment links whenever they are saved.
+	AddDidSaveLinkChannel(chan *cs.Link)
+
+	// Adds a channel that receives segment evidences whenever they are saved.
+	AddDidSaveEvidenceChannel(chan *cs.Evidence)
+
+	// Creates a new Batch
+	NewBatch() (BatchV2, error)
+}
+
+// KeyValueReader is the interface for reading key-value pairs.
+type KeyValueReader interface {
+	GetValue(key []byte) ([]byte, error)
+}
+
+// KeyValueWriter is the interface for writing key-value pairs.
+type KeyValueWriter interface {
+	SetValue(key []byte, value []byte) error
+	DeleteValue(key []byte) ([]byte, error)
+}
+
+// KeyValueStore is the interface for a key-value store.
+// Some store adapters will implement this interface, but not all.
+type KeyValueStore interface {
+	KeyValueReader
+	KeyValueWriter
+}
+
+/* End of updated store interfaces. */
+
 // Pagination contains pagination options.
 type Pagination struct {
 	// Index of the first entry.


### PR DESCRIPTION
Define the new interfaces we want to migrate to.
We will then migrate our existing stores one by one, and when all are migrated we'll remove the old interfaces and remove the "V2" in some interface names.

In the next pull requests I'll prepare today to setup that work, I'll:
  * Update storetestcases to test stores through these new interfaces when they support it
  * Migrate FileStore to the new interfaces to see if it hits some issues

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stratumn/sdk/239)
<!-- Reviewable:end -->
