### PR TITLE
couchstore: add integration flag for tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,6 @@ install:
   - go get -u github.com/golang/lint/golint
   - dep ensure
 script:
-  - docker run -p 5984:5984 -d couchdb
   - make coverage && make lint
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/couchstore/couchstore_test.go
+++ b/couchstore/couchstore_test.go
@@ -15,6 +15,7 @@
 package couchstore
 
 import (
+	"flag"
 	"testing"
 
 	"github.com/stratumn/sdk/store"
@@ -25,14 +26,18 @@ import (
 var (
 	myCouchstore *CouchStore
 	test         *testing.T
+	integration  = flag.Bool("integration", false, "Run integration tests")
 )
 
 func TestCouchStore(t *testing.T) {
+	flag.Parse()
 	test = t
-	storetestcases.Factory{
-		New:  newTestCouchStore,
-		Free: freeTestCouchStore,
-	}.RunTests(t)
+	if *integration {
+		storetestcases.Factory{
+			New:  newTestCouchStore,
+			Free: freeTestCouchStore,
+		}.RunTests(t)
+	}
 }
 
 func newTestCouchStore() (store.Adapter, error) {


### PR DESCRIPTION
This is a temporary solution until we launch a couchdb instance from couchstore TestMain rather than within Travis.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stratumn/sdk/240)
<!-- Reviewable:end -->
