### PR TITLE
couchstore: clean adapter init in test

### DIFF
--- a/couchstore/couchstore_test.go
+++ b/couchstore/couchstore_test.go
@@ -41,16 +41,10 @@ func TestCouchStore(t *testing.T) {
 }
 
 func newTestCouchStore() (store.Adapter, error) {
-	var err error
 	config := &Config{
 		Address: "http://localhost:5984",
 	}
-	myCouchstore, err = New(config)
-	if err != nil {
-		test.Logf(err.Error())
-		test.FailNow()
-	}
-	return myCouchstore, nil
+	return New(config)
 }
 
 func freeTestCouchStore(a store.Adapter) {


### PR DESCRIPTION
initAdapter in storetestcases already logs in any error that might
happen during initialization.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stratumn/sdk/243)
<!-- Reviewable:end -->
