### PR TITLE
filestore: update to new store interface

### DIFF
--- a/cs/cs.go
+++ b/cs/cs.go
@@ -52,7 +52,7 @@ func (s *Segment) GetLinkHashString() string {
 
 // HashLink hashes the segment link and stores it into the Meta
 func (s *Segment) HashLink() (string, error) {
-	return s.Link.Hash()
+	return s.Link.HashString()
 }
 
 // SetLinkHash overwrites the segment LinkHash using HashLink()
@@ -239,7 +239,18 @@ type Link struct {
 }
 
 // Hash hashes the link
-func (l *Link) Hash() (string, error) {
+func (l *Link) Hash() (*types.Bytes32, error) {
+	jsonLink, err := cj.Marshal(l)
+	if err != nil {
+		return nil, err
+	}
+	byteLinkHash := sha256.Sum256(jsonLink)
+	linkHash := types.Bytes32(byteLinkHash)
+	return &linkHash, nil
+}
+
+// HashString hashes the link and returns a string
+func (l *Link) HashString() (string, error) {
 	jsonLink, err := cj.Marshal(l)
 	if err != nil {
 		return "", err

--- a/cs/cs.go
+++ b/cs/cs.go
@@ -17,7 +17,6 @@ package cs
 
 import (
 	"crypto/sha256"
-	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"math"
@@ -251,12 +250,12 @@ func (l *Link) Hash() (*types.Bytes32, error) {
 
 // HashString hashes the link and returns a string
 func (l *Link) HashString() (string, error) {
-	jsonLink, err := cj.Marshal(l)
+	hash, err := l.Hash()
 	if err != nil {
 		return "", err
 	}
-	byteLinkHash := sha256.Sum256(jsonLink)
-	return hex.EncodeToString(byteLinkHash[:sha256.Size]), nil
+
+	return hash.String(), nil
 }
 
 // GetPriority returns the priority as a float64

--- a/cs/cs.go
+++ b/cs/cs.go
@@ -52,12 +52,7 @@ func (s *Segment) GetLinkHashString() string {
 
 // HashLink hashes the segment link and stores it into the Meta
 func (s *Segment) HashLink() (string, error) {
-	jsonLink, err := cj.Marshal(s.Link)
-	if err != nil {
-		return "", err
-	}
-	byteLinkHash := sha256.Sum256(jsonLink)
-	return hex.EncodeToString(byteLinkHash[:sha256.Size]), nil
+	return s.Link.Hash()
 }
 
 // SetLinkHash overwrites the segment LinkHash using HashLink()
@@ -243,6 +238,16 @@ type Link struct {
 	Meta  map[string]interface{} `json:"meta"`
 }
 
+// Hash hashes the link
+func (l *Link) Hash() (string, error) {
+	jsonLink, err := cj.Marshal(l)
+	if err != nil {
+		return "", err
+	}
+	byteLinkHash := sha256.Sum256(jsonLink)
+	return hex.EncodeToString(byteLinkHash[:sha256.Size]), nil
+}
+
 // GetPriority returns the priority as a float64
 // It assumes the link is valid.
 // If priority is nil, it will return -Infinity.
@@ -261,7 +266,7 @@ func (l *Link) GetMapID() string {
 
 // GetPrevLinkHash returns the previous link hash as a bytes.
 // It assumes the link is valid.
-// It will return nilif the previous link hash is null.
+// It will return nil if the previous link hash is null.
 func (l *Link) GetPrevLinkHash() *types.Bytes32 {
 	if str, ok := l.Meta["prevLinkHash"].(string); ok {
 		b, _ := types.NewBytes32FromString(str)

--- a/cs/cs_test.go
+++ b/cs/cs_test.go
@@ -494,11 +494,9 @@ func TestMergeMeta(t *testing.T) {
 	s1 := cstesting.RandomSegment()
 	e1 := TestEvidence
 	e1.State = cs.PendingEvidence
-	s1.Meta.Data["test"] = "test"
 	s1.Meta.AddEvidence(e1)
 
 	s2 := cstesting.RandomSegment()
-	s2.Meta.Data["test"] = "update"
 	s2.Meta.LinkHash = s1.Meta.LinkHash
 	e2 := TestEvidence
 	e2.Provider = "xyz"
@@ -519,9 +517,6 @@ func TestMergeMeta(t *testing.T) {
 		}
 		if len(s1.Meta.Evidences) != 2 {
 			t.Errorf("Segment.MergeMeta(): len(s1.Meta.Evidences) = %d, want %d", len(s1.Meta.Evidences), 2)
-		}
-		if s1.Meta.Data["test"] != "update" {
-			t.Errorf(`Segment.MergeMeta(): s1.Meta.Data["test"] = %s, want %s`, s1.Meta.Data["test"], "update")
 		}
 		if s1.Meta.GetEvidence(e1.Provider).State == cs.PendingEvidence {
 			t.Errorf("Segment.MergeMeta(): Evidence state is %s, want %s", cs.PendingEvidence, cs.CompleteEvidence)

--- a/cs/cstesting/cstesting.go
+++ b/cs/cstesting/cstesting.go
@@ -47,9 +47,7 @@ func CreateSegment(process, mapID, prevLinkHash string, tags []interface{}, prio
 			},
 			Meta: linkMeta,
 		},
-		Meta: cs.SegmentMeta{
-			Data: map[string]interface{}{"random": "random"},
-		},
+		Meta: cs.SegmentMeta{},
 	}
 	segment.SetLinkHash()
 

--- a/filestore/batch.go
+++ b/filestore/batch.go
@@ -48,9 +48,9 @@ func (b *Batch) Write() (err error) {
 	for _, op := range b.SegmentOps {
 		switch op.OpType {
 		case bufferedbatch.OpTypeSet:
-			err = b.originalFileStore.saveSegment(op.Segment)
+			err = b.originalFileStore.saveSegment(op.Segment, false)
 		case bufferedbatch.OpTypeDelete:
-			_, err = b.originalFileStore.deleteSegment(op.LinkHash)
+			_, err = b.originalFileStore.deleteSegment(op.LinkHash, false)
 		default:
 			err = fmt.Errorf("Invalid Batch operation type: %v", op.OpType)
 		}

--- a/filestore/batch.go
+++ b/filestore/batch.go
@@ -48,9 +48,9 @@ func (b *Batch) Write() (err error) {
 	for _, op := range b.SegmentOps {
 		switch op.OpType {
 		case bufferedbatch.OpTypeSet:
-			err = b.originalFileStore.saveSegment(op.Segment, false)
+			err = b.originalFileStore.saveSegment(op.Segment)
 		case bufferedbatch.OpTypeDelete:
-			_, err = b.originalFileStore.deleteSegment(op.LinkHash, false)
+			_, err = b.originalFileStore.deleteSegment(op.LinkHash)
 		default:
 			err = fmt.Errorf("Invalid Batch operation type: %v", op.OpType)
 		}

--- a/filestore/filestore.go
+++ b/filestore/filestore.go
@@ -128,12 +128,10 @@ func (a *FileStore) createLink(link *cs.Link, lock bool) (*types.Bytes32, error)
 		defer a.mutex.Unlock()
 	}
 
-	linkHashStr, err := link.Hash()
+	linkHash, err := link.Hash()
 	if err != nil {
 		return nil, err
 	}
-
-	linkHash, _ := types.NewBytes32FromString(linkHashStr)
 
 	if err = a.initDir(); err != nil {
 		return nil, err
@@ -144,7 +142,7 @@ func (a *FileStore) createLink(link *cs.Link, lock bool) (*types.Bytes32, error)
 		return nil, err
 	}
 
-	linkPath := a.getLinkPath(linkHashStr)
+	linkPath := a.getLinkPath(linkHash)
 
 	if err := ioutil.WriteFile(linkPath, js, 0644); err != nil {
 		return nil, err
@@ -247,7 +245,7 @@ func (a *FileStore) deleteSegment(linkHash *types.Bytes32, lock bool) (*cs.Segme
 		return segment, err
 	}
 
-	if err = os.Remove(a.getLinkPath(linkHash.String())); err != nil {
+	if err = os.Remove(a.getLinkPath(linkHash)); err != nil {
 		return nil, err
 	}
 
@@ -347,8 +345,7 @@ func (a *FileStore) getLink(linkHash *types.Bytes32, lock bool) (*cs.Link, error
 		defer a.mutex.RUnlock()
 	}
 
-	linkHashStr := linkHash.String()
-	file, err := os.Open(a.getLinkPath(linkHashStr))
+	file, err := os.Open(a.getLinkPath(linkHash))
 	if os.IsNotExist(err) {
 		return nil, nil
 	}
@@ -409,8 +406,8 @@ func (a *FileStore) initDir() error {
 	return nil
 }
 
-func (a *FileStore) getLinkPath(linkHash string) string {
-	return path.Join(a.config.Path, linkHash+".json")
+func (a *FileStore) getLinkPath(linkHash *types.Bytes32) string {
+	return path.Join(a.config.Path, linkHash.String()+".json")
 }
 
 var linkFileRegex = regexp.MustCompile("(.*)\\.json$")

--- a/store/store.go
+++ b/store/store.go
@@ -139,7 +139,7 @@ type BatchV2 interface {
 	LinkWriter
 
 	// Write definitely writes the content of the Batch
-	Write() error
+	WriteV2() error
 }
 
 // EventType lets you know the kind of event received.
@@ -173,7 +173,7 @@ type AdapterV2 interface {
 	AddStoreEventChannel(chan *Event)
 
 	// Creates a new Batch
-	NewBatch() (BatchV2, error)
+	NewBatchV2() (BatchV2, error)
 }
 
 // KeyValueReader is the interface for reading key-value pairs.

--- a/tmpop/tmpoptestcases/transaction.go
+++ b/tmpop/tmpoptestcases/transaction.go
@@ -62,7 +62,6 @@ func (f Factory) TestTx(t *testing.T) {
 
 	t.Run("WriteDoubleSaveSegment()", func(t *testing.T) {
 		s := cstesting.RandomSegment()
-		s.Meta.Data["test"] = "test"
 		tx := makeSaveSegmentTxFromSegment(t, s)
 		h.BeginBlock(requestBeginBlock)
 
@@ -78,11 +77,9 @@ func (f Factory) TestTx(t *testing.T) {
 		if ev.State != cs.PendingEvidence {
 			t.Errorf("h.DeliverTx(): wrong evidence state after saving segment, got %s, want %s", ev.State, cs.PendingEvidence)
 		}
-		if got.Meta.Data["test"] != "test" {
-			t.Errorf("h.DeliverTx(): wrong segment.Meta.Data after saving, got %s, want %s", got.Meta.Data, s.Meta.Data)
-		}
+
 		// We try to save a segment with the same link (and linkHash)
-		// but with new evidences and meta data
+		// but with new evidences
 		newRequest := requestBeginBlock
 		newRequest.Header.AppHash = res.Data.Bytes()
 
@@ -97,8 +94,6 @@ func (f Factory) TestTx(t *testing.T) {
 			Backend:  "TMPop",
 			Proof:    nil,
 		})
-		s.Meta.Data["random"] = nil
-		s.Meta.Data["test"] = "random"
 		tx = makeSaveSegmentTxFromSegment(t, s)
 		h.DeliverTx(tx)
 		h.Commit()
@@ -114,9 +109,6 @@ func (f Factory) TestTx(t *testing.T) {
 		}
 		if len(got.Meta.Evidences) != 3 {
 			t.Errorf("h.DeliverTx(): wrong length of segment.Meta.Evidences, got %d want %d", len(got.Meta.Evidences), 3)
-		}
-		if got.Meta.Data["test"] != "random" || got.Meta.Data["random"] != nil {
-			t.Errorf("h.DeliverTx(): wrong segment.Meta.Data after saving, got %s, want %s", got.Meta.Data, s.Meta.Data)
 		}
 	})
 


### PR DESCRIPTION
Doing the migration on FileStore helped me find the pain points that we'll experience on stores.
I think we need to get rid of the Segment.Meta.Data map right now (it's useless to write code to support that in the new methods since we want to remove it anyway) -> I removed tests on that feature.

We need to do a bit of MergeMeta magic in the implementation of AddEvidence which will probably end up somewhat duplicated in all stores during the migration, but since we'll remove this and get rid of the "pending" state after the migration I think it's ok for now.

I didn't do the implementation of BatchV2 right now: I think that BatchV2 will be much simpler than Batch(V1) since the only operation will be "createLink" so we can update bufferedbatch at the end of the migration to directly implement BatchV2 and update all stores in the same PR.

Overall I think at the end of the migration we'll have less code in the stores, and we'll have removed some complexities about merging meta so our code will be simpler :)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stratumn/sdk/247)
<!-- Reviewable:end -->
