### PR TITLE
bufferedbatch: batch v2 implementation

### DIFF
--- a/bufferedbatch/batchV2.go
+++ b/bufferedbatch/batchV2.go
@@ -1,0 +1,120 @@
+// Copyright 2017 Stratumn SAS. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bufferedbatch
+
+import (
+	"github.com/stratumn/sdk/cs"
+	"github.com/stratumn/sdk/store"
+	"github.com/stratumn/sdk/types"
+)
+
+// BatchV2 can be used as a base class for types
+// that want to implement github.com/stratumn/sdk/store.BatchV2.
+// All operations are stored in arrays and can be replayed.
+// Only the WriteV2 method must be implemented.
+type BatchV2 struct {
+	originalStore store.AdapterV2
+	Links         []*cs.Link
+}
+
+// NewBatchV2 creates a new BatchV2.
+func NewBatchV2(a store.AdapterV2) *BatchV2 {
+	return &BatchV2{originalStore: a}
+}
+
+// CreateLink implements github.com/stratumn/sdk/store.LinkWriter.CreateLink.
+func (b *BatchV2) CreateLink(link *cs.Link) (*types.Bytes32, error) {
+	segment := link.Segmentify()
+	if err := segment.Validate(b.GetSegment); err != nil {
+		return nil, err
+	}
+	b.Links = append(b.Links, link)
+	return segment.GetLinkHash(), nil
+}
+
+// GetSegment returns a segment from the cache or delegates the call to the store.
+func (b *BatchV2) GetSegment(linkHash *types.Bytes32) (segment *cs.Segment, err error) {
+	for _, link := range b.Links {
+		lh, err := link.Hash()
+		if err != nil {
+			return nil, err
+		}
+
+		if *lh == *linkHash {
+			segment = link.Segmentify()
+		}
+	}
+
+	if segment != nil {
+		return segment, nil
+	}
+
+	return b.originalStore.GetSegment(linkHash)
+}
+
+// FindSegments returns the union of segments in the store and not committed yet.
+func (b *BatchV2) FindSegments(filter *store.SegmentFilter) (cs.SegmentSlice, error) {
+	segments, err := b.originalStore.FindSegments(filter)
+	if err != nil {
+		return segments, err
+	}
+
+	for _, link := range b.Links {
+		if filter.MatchLink(link) {
+			segments = append(segments, link.Segmentify())
+		}
+	}
+
+	return filter.Pagination.PaginateSegments(segments), nil
+}
+
+// GetMapIDs returns the union of mapIds in the store and not committed yet.
+func (b *BatchV2) GetMapIDs(filter *store.MapFilter) ([]string, error) {
+	tmpMapIDs, err := b.originalStore.GetMapIDs(filter)
+	if err != nil {
+		return tmpMapIDs, err
+	}
+	mapIDs := make(map[string]int, len(tmpMapIDs))
+	for _, m := range tmpMapIDs {
+		mapIDs[m] = 0
+	}
+
+	// Apply uncommitted links
+	for _, link := range b.Links {
+		if filter.MatchLink(link) {
+			mapID := link.Meta["mapId"].(string)
+			mapIDs[mapID]++
+		}
+	}
+
+	ids := make([]string, 0, len(mapIDs))
+	for k := range mapIDs {
+		ids = append(ids, k)
+	}
+
+	return filter.Pagination.PaginateStrings(ids), err
+}
+
+// WriteV2 implements github.com/stratumn/sdk/store.BatchV2.WriteV2.
+func (b *BatchV2) WriteV2() (err error) {
+	for _, link := range b.Links {
+		_, err = b.originalStore.CreateLink(link)
+		if err != nil {
+			break
+		}
+	}
+
+	return
+}

--- a/bufferedbatch/batchV2_test.go
+++ b/bufferedbatch/batchV2_test.go
@@ -1,0 +1,301 @@
+// Copyright 2017 Stratumn SAS. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bufferedbatch
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/stratumn/sdk/cs"
+	"github.com/stratumn/sdk/cs/cstesting"
+	"github.com/stratumn/sdk/store"
+	"github.com/stratumn/sdk/store/storetesting"
+	"github.com/stratumn/sdk/types"
+)
+
+func TestBatchV2_CreateLink(t *testing.T) {
+	a := &storetesting.MockAdapter{}
+	batch := NewBatchV2(a)
+
+	l := cstesting.RandomLink()
+
+	wantedErr := errors.New("error on MockCreateLink")
+	a.MockCreateLink.Fn = func(link *cs.Link) (*types.Bytes32, error) { return nil, wantedErr }
+
+	if _, err := batch.CreateLink(l); err != nil {
+		t.Fatalf("batch.CreateLink(): err: %s", err)
+	}
+	if got, want := a.MockCreateLink.CalledCount, 0; got != want {
+		t.Errorf("batch.MockCreateLink.CalledCount = %d want %d", got, want)
+	}
+	if got, want := len(batch.Links), 1; got != want {
+		t.Errorf("len(batch.Links) = %d want %d", got, want)
+	}
+
+	l.Meta["mapId"] = ""
+	if _, err := batch.CreateLink(l); err == nil {
+		t.Fatal("batch.CreateLink() should return an error when mapId is missing")
+	}
+}
+
+func TestBatchV2_GetSegment(t *testing.T) {
+	a := &storetesting.MockAdapter{}
+	batch := NewBatchV2(a)
+
+	storedLink := cstesting.RandomLink()
+	storedLinkHash, _ := storedLink.Hash()
+	batchLink1 := cstesting.RandomLink()
+	batchLink2 := cstesting.RandomLink()
+
+	batchLinkHash1, _ := batch.CreateLink(batchLink1)
+	batchLinkHash2, _ := batch.CreateLink(batchLink2)
+
+	notFoundErr := errors.New("Unit test error")
+	a.MockGetSegment.Fn = func(linkHash *types.Bytes32) (*cs.Segment, error) {
+		if *storedLinkHash == *linkHash {
+			return storedLink.Segmentify(), nil
+		}
+
+		return nil, notFoundErr
+	}
+
+	var segment *cs.Segment
+	var err error
+
+	segment, err = batch.GetSegment(batchLinkHash1)
+	if err != nil {
+		t.Fatalf("batch.GetSegment(): err: %s", err)
+	}
+	if got, want := segment.Link, *batchLink1; !reflect.DeepEqual(got, want) {
+		t.Errorf("link = %v want %v", got, want)
+	}
+
+	segment, err = batch.GetSegment(batchLinkHash2)
+	if err != nil {
+		t.Fatalf("batch.GetSegment(): err: %s", err)
+	}
+	if got, want := segment.Link, *batchLink2; !reflect.DeepEqual(got, want) {
+		t.Errorf("link = %v want %v", got, want)
+	}
+
+	segment, err = batch.GetSegment(storedLinkHash)
+	if err != nil {
+		t.Fatalf("batch.GetSegment(): err: %s", err)
+	}
+	if got, want := segment.Link, *storedLink; !reflect.DeepEqual(got, want) {
+		t.Errorf("link = %v want %v", got, want)
+	}
+
+	segment, err = batch.GetSegment(cstesting.RandomSegment().GetLinkHash())
+	if got, want := err, notFoundErr; got != want {
+		t.Errorf("GetSegment should return an error: %s want %s", got, want)
+	}
+}
+
+func TestBatchV2_FindSegments(t *testing.T) {
+	a := &storetesting.MockAdapter{}
+	batch := NewBatchV2(a)
+
+	storedLink := cstesting.RandomLink()
+	storedLink.Meta["process"] = "Foo"
+	l1 := cstesting.RandomLink()
+	l1.Meta["process"] = "Foo"
+	l2 := cstesting.RandomLink()
+	l2.Meta["process"] = "Bar"
+
+	batch.CreateLink(l1)
+	batch.CreateLink(l2)
+
+	notFoundErr := errors.New("Unit test error")
+	a.MockFindSegments.Fn = func(filter *store.SegmentFilter) (cs.SegmentSlice, error) {
+		if filter.Process == "Foo" {
+			return cs.SegmentSlice{storedLink.Segmentify()}, nil
+		}
+		if filter.Process == "Bar" {
+			return cs.SegmentSlice{}, nil
+		}
+
+		return nil, notFoundErr
+	}
+
+	var segments cs.SegmentSlice
+	var err error
+
+	segments, err = batch.FindSegments(&store.SegmentFilter{Pagination: store.Pagination{Limit: store.DefaultLimit}, Process: "Foo"})
+	if err != nil {
+		t.Fatalf("batch.FindSegments(): err: %s", err)
+	}
+	if got, want := len(segments), 2; got != want {
+		t.Errorf("segment slice length = %d want %d", got, want)
+	}
+
+	segments, err = batch.FindSegments(&store.SegmentFilter{Pagination: store.Pagination{Limit: store.DefaultLimit}, Process: "Bar"})
+	if err != nil {
+		t.Fatalf("batch.FindSegments(): err: %s", err)
+	}
+	if got, want := len(segments), 1; got != want {
+		t.Errorf("segment slice length = %d want %d", got, want)
+	}
+
+	segments, err = batch.FindSegments(&store.SegmentFilter{Pagination: store.Pagination{Limit: store.DefaultLimit}, Process: "NotFound"})
+	if got, want := err, notFoundErr; got != want {
+		t.Errorf("FindSegments should return an error: %s want %s", got, want)
+	}
+}
+
+func TestBatchV2_GetMapIDs(t *testing.T) {
+	a := &storetesting.MockAdapter{}
+	batch := NewBatchV2(a)
+
+	storedLink1 := cstesting.RandomLink()
+	storedLink1.Meta["mapId"] = "Foo1"
+	storedLink1.Meta["process"] = "FooProcess"
+	storedLink2 := cstesting.RandomLink()
+	storedLink2.Meta["mapId"] = "Bar"
+	storedLink2.Meta["process"] = "BarProcess"
+
+	batchLink1 := cstesting.RandomLink()
+	batchLink1.Meta["mapId"] = "Foo2"
+	batchLink1.Meta["process"] = "FooProcess"
+	batchLink2 := cstesting.RandomLink()
+	batchLink2.Meta["mapId"] = "Yin"
+	batchLink2.Meta["process"] = "YinProcess"
+
+	batch.CreateLink(batchLink1)
+	batch.CreateLink(batchLink2)
+
+	a.MockGetMapIDs.Fn = func(filter *store.MapFilter) ([]string, error) {
+		if filter.Process == storedLink1.Meta["process"] {
+			return []string{storedLink1.Meta["mapId"].(string)}, nil
+		}
+		if filter.Process == storedLink2.Meta["process"] {
+			return []string{storedLink2.Meta["mapId"].(string)}, nil
+		}
+
+		return []string{
+			storedLink1.Meta["mapId"].(string),
+			storedLink2.Meta["mapId"].(string),
+		}, nil
+	}
+
+	var mapIDs []string
+	var err error
+
+	mapIDs, err = batch.GetMapIDs(&store.MapFilter{Pagination: store.Pagination{Limit: store.DefaultLimit}})
+	if err != nil {
+		t.Fatalf("batch.GetMapIDs(): err: %s", err)
+	}
+	if got, want := len(mapIDs), 4; got != want {
+		t.Errorf("mapIds length = %d want %d / values = %v", got, want, mapIDs)
+	}
+
+	processFilter := &store.MapFilter{
+		Process:    "FooProcess",
+		Pagination: store.Pagination{Limit: store.DefaultLimit},
+	}
+	mapIDs, err = batch.GetMapIDs(processFilter)
+	if err != nil {
+		t.Fatalf("batch.GetMapIDs(): err: %s", err)
+	}
+	if got, want := len(mapIDs), 2; got != want {
+		t.Errorf("mapIds length = %d want %d / values = %v", got, want, mapIDs)
+	}
+	for _, mapID := range []string{
+		storedLink1.GetMapID(),
+		batchLink1.GetMapID(),
+	} {
+		if mapIDs[0] != mapID && mapIDs[1] != mapID {
+			t.Errorf("Invalid mapId returned: %v", mapID)
+		}
+	}
+}
+
+func TestBatchV2_GetMapIDsWithStoreReturningAnErrorOnGetMapIDs(t *testing.T) {
+	a := &storetesting.MockAdapter{}
+	batch := NewBatchV2(a)
+
+	wantedMapIds := []string{"Foo", "Bar"}
+	notFoundErr := errors.New("Unit test error")
+	a.MockGetMapIDs.Fn = func(filter *store.MapFilter) ([]string, error) {
+		return wantedMapIds, notFoundErr
+	}
+
+	if mapIDs, err := batch.GetMapIDs(&store.MapFilter{}); err == nil {
+		t.Fatal("batch.GetMapIDs() should return an error")
+	} else if got, want := len(mapIDs), len(wantedMapIds); got != want {
+		t.Fatalf("mapIds length = %d want %d", got, want)
+	} else if got, want := mapIDs, wantedMapIds; !reflect.DeepEqual(got, want) {
+		t.Fatalf("mapIds = %v want %v", got, want)
+	}
+}
+
+// TestBatchV2_WriteLink tests what happens when creating a link
+func TestBatchV2_WriteLink(t *testing.T) {
+	a := &storetesting.MockAdapter{}
+	l := cstesting.RandomLink()
+
+	batch := NewBatchV2(a)
+
+	_, err := batch.CreateLink(l)
+	if err != nil {
+		t.Fatalf("batch.CreateLink(): err: %s", err)
+	}
+
+	err = batch.WriteV2()
+	if err != nil {
+		t.Fatalf("batch.Write(): err: %s", err)
+	}
+
+	if got, want := a.MockCreateLink.CalledCount, 1; got != want {
+		t.Errorf("batch.Write(): expected to have called CreateLink %d time, got %d", want, got)
+	}
+
+	if got, want := a.MockCreateLink.LastCalledWith, l; got != want {
+		t.Errorf("batch.Write(): expected to have called CreateLink with %v, got %v", want, got)
+	}
+}
+
+// TestBatchV2_WriteLinkWithFailure tests what happens when a write fails
+func TestBatchV2_WriteLinkWithFailure(t *testing.T) {
+	a := &storetesting.MockAdapter{}
+	mockError := errors.New("Error")
+
+	la := cstesting.RandomLink()
+	lb := cstesting.RandomLink()
+
+	a.MockCreateLink.Fn = func(l *cs.Link) (*types.Bytes32, error) {
+		if l == la {
+			return nil, mockError
+		}
+		return l.Hash()
+	}
+
+	batch := NewBatchV2(a)
+
+	_, err := batch.CreateLink(la)
+	if err != nil {
+		t.Fatalf("batch.CreateLink(): err: %s", err)
+	}
+
+	_, err = batch.CreateLink(lb)
+	if err != nil {
+		t.Fatalf("batch.CreateLink(): err: %s", err)
+	}
+
+	if got, want := batch.WriteV2(), mockError; got != want {
+		t.Errorf("batch.Write returned %v want %v", got, want)
+	}
+}

--- a/cs/cs.go
+++ b/cs/cs.go
@@ -329,10 +329,10 @@ func (l *Link) GetProcess() string {
 
 // Segmentify returns a segment from a link,
 // filling the link hash and appropriate meta.
-func (l *Link) Segmentify() *Segment {
+func (l Link) Segmentify() *Segment {
 	linkHash, _ := l.HashString()
 	return &Segment{
-		Link: *l,
+		Link: l,
 		Meta: SegmentMeta{
 			LinkHash: linkHash,
 		},

--- a/cs/cs.go
+++ b/cs/cs.go
@@ -327,6 +327,18 @@ func (l *Link) GetProcess() string {
 	return l.Meta["process"].(string)
 }
 
+// Segmentify returns a segment from a link,
+// filling the link hash and appropriate meta.
+func (l *Link) Segmentify() *Segment {
+	linkHash, _ := l.HashString()
+	return &Segment{
+		Link: *l,
+		Meta: SegmentMeta{
+			LinkHash: linkHash,
+		},
+	}
+}
+
 // SegmentSlice is a slice of segment pointers.
 type SegmentSlice []*Segment
 

--- a/store/store.go
+++ b/store/store.go
@@ -268,14 +268,23 @@ func min(a, b int) int {
 	return b
 }
 
-// Match check if segment matches with filter
+// Match checks if segment matches with filter
 func (filter SegmentFilter) Match(segment *cs.Segment) bool {
 	if segment == nil {
 		return false
 	}
 
+	return filter.MatchLink(&segment.Link)
+}
+
+// MatchLink checks if link matches with filter
+func (filter SegmentFilter) MatchLink(link *cs.Link) bool {
+	if link == nil {
+		return false
+	}
+
 	if filter.PrevLinkHash != nil {
-		prevLinkHash := segment.Link.GetPrevLinkHash()
+		prevLinkHash := link.GetPrevLinkHash()
 		if *filter.PrevLinkHash == "" {
 			if prevLinkHash != nil {
 				return false
@@ -289,9 +298,10 @@ func (filter SegmentFilter) Match(segment *cs.Segment) bool {
 	}
 
 	if len(filter.LinkHashes) > 0 {
+		lh, _ := link.Hash()
 		var match bool
 		for _, linkHash := range filter.LinkHashes {
-			if linkHash.Compare(segment.GetLinkHash()) == 0 {
+			if linkHash.Compare(lh) == 0 {
 				match = true
 				break
 			}
@@ -301,13 +311,13 @@ func (filter SegmentFilter) Match(segment *cs.Segment) bool {
 		}
 	}
 
-	if filter.Process != "" && filter.Process != segment.Link.GetProcess() {
+	if filter.Process != "" && filter.Process != link.GetProcess() {
 		return false
 	}
 
 	if len(filter.MapIDs) > 0 {
 		var match = false
-		mapID := segment.Link.GetMapID()
+		mapID := link.GetMapID()
 		for _, filterMapIDs := range filter.MapIDs {
 			match = match || filterMapIDs == mapID
 		}
@@ -317,7 +327,7 @@ func (filter SegmentFilter) Match(segment *cs.Segment) bool {
 	}
 
 	if len(filter.Tags) > 0 {
-		tags := segment.Link.GetTagMap()
+		tags := link.GetTagMap()
 		for _, tag := range filter.Tags {
 			if _, ok := tags[tag]; !ok {
 				return false

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -41,7 +41,6 @@ var (
 
 func init() {
 	prevLinkHashTestingValue = testutil.RandomHash().String()
-	linkHashTestingValue = testutil.RandomHash().String()
 	badLinkHashTestingValue = testutil.RandomHash().String()
 
 	segmentSlice = make(cs.SegmentSlice, sliceSize)
@@ -53,20 +52,16 @@ func init() {
 }
 
 func defaultTestingSegment() *cs.Segment {
-	return &cs.Segment{
-		Link: cs.Link{
-			Meta: map[string]interface{}{
-				"prevLinkHash": prevLinkHashTestingValue,
-				"process":      "TheProcess",
-				"mapId":        "TheMapId",
-				"tags":         []interface{}{"Foo", "Bar"},
-				"priority":     42,
-			},
-		},
-		Meta: cs.SegmentMeta{
-			LinkHash: linkHashTestingValue,
+	link := &cs.Link{
+		Meta: map[string]interface{}{
+			"prevLinkHash": prevLinkHashTestingValue,
+			"process":      "TheProcess",
+			"mapId":        "TheMapId",
+			"tags":         []interface{}{"Foo", "Bar"},
+			"priority":     42,
 		},
 	}
+	return link.Segmentify()
 }
 
 func emptyPrevLinkHashTestingSegment() *cs.Segment {


### PR DESCRIPTION
Implement a batch v2 buffered batch.
It will most likely be used as-is in all our stores since the batch is now simpler than what it was previously.
Note: I found it horrible to have to manually implement the mocks, we need to take some time to find a good package to do that for us (and at the same time add a good assertions library for our unit tests).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stratumn/sdk/258)
<!-- Reviewable:end -->
