### PR TITLE
validator: provide a validations hash

### DIFF
--- a/validator/root.go
+++ b/validator/root.go
@@ -1,6 +1,7 @@
 package validator
 
 import (
+	"crypto/sha256"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -9,11 +10,13 @@ import (
 
 	"github.com/stratumn/sdk/cs"
 	"github.com/stratumn/sdk/store"
+	"github.com/stratumn/sdk/types"
 
 	log "github.com/sirupsen/logrus"
 )
 
 type rootValidator struct {
+	hash                *types.Bytes32
 	ValidByDefault      bool
 	ValidatorsByProcess map[string][]selectiveValidator
 }
@@ -45,6 +48,8 @@ func NewRootValidator(filename string, validByDefault bool) Validator {
 		log.Error(err)
 	}
 
+	v.updateHash(data)
+
 	return &v
 }
 
@@ -67,6 +72,10 @@ func (rv rootValidator) Validate(store store.Reader, segment *cs.Segment) error 
 		return errors.New("root validation failed")
 	}
 	return nil
+}
+
+func (rv rootValidator) Hash() *types.Bytes32 {
+	return rv.hash
 }
 
 func (rv *rootValidator) loadFromJSON(data []byte) error {
@@ -104,4 +113,10 @@ func (rv *rootValidator) loadFromJSON(data []byte) error {
 	log.Debugf("validators loaded: %d", len(rv.ValidatorsByProcess))
 
 	return nil
+}
+
+func (rv *rootValidator) updateHash(data []byte) {
+	byteHash := sha256.Sum256(data)
+	validationsHash := types.Bytes32(byteHash)
+	rv.hash = &validationsHash
 }

--- a/validator/root.go
+++ b/validator/root.go
@@ -22,7 +22,7 @@ type rootValidator struct {
 }
 
 type selectiveValidator interface {
-	Validator
+	validator
 	Filter(store.Reader, *cs.Segment) bool
 }
 
@@ -48,7 +48,9 @@ func NewRootValidator(filename string, validByDefault bool) Validator {
 		log.Error(err)
 	}
 
-	v.updateHash(data)
+	if data != nil && len(data) > 0 {
+		v.updateHash(data)
+	}
 
 	return &v
 }

--- a/validator/schema.go
+++ b/validator/schema.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stratumn/sdk/cs"
 	"github.com/stratumn/sdk/store"
+	"github.com/stratumn/sdk/types"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/xeipuuv/gojsonschema"
@@ -57,5 +58,9 @@ func (sv schemaValidator) Validate(_ store.Reader, segment *cs.Segment) error {
 	if !result.Valid() {
 		return fmt.Errorf("segment validation failed: %s", result.Errors())
 	}
+	return nil
+}
+
+func (sv schemaValidator) Hash() *types.Bytes32 {
 	return nil
 }

--- a/validator/schema.go
+++ b/validator/schema.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/stratumn/sdk/cs"
 	"github.com/stratumn/sdk/store"
-	"github.com/stratumn/sdk/types"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/xeipuuv/gojsonschema"
@@ -58,9 +57,5 @@ func (sv schemaValidator) Validate(_ store.Reader, segment *cs.Segment) error {
 	if !result.Valid() {
 		return fmt.Errorf("segment validation failed: %s", result.Errors())
 	}
-	return nil
-}
-
-func (sv schemaValidator) Hash() *types.Bytes32 {
 	return nil
 }

--- a/validator/validator.go
+++ b/validator/validator.go
@@ -11,8 +11,13 @@ const (
 	DefaultFilename = "/data/validation/rules.json"
 )
 
-// Validator defines the interface with single Validate() method
-type Validator interface {
+// validator defines the interface with single Validate() method
+type validator interface {
 	Validate(store.Reader, *cs.Segment) error
+}
+
+// Validator defines a validator that can be identified by a hash
+type Validator interface {
+	validator
 	Hash() *types.Bytes32
 }

--- a/validator/validator.go
+++ b/validator/validator.go
@@ -3,6 +3,7 @@ package validator
 import (
 	"github.com/stratumn/sdk/cs"
 	"github.com/stratumn/sdk/store"
+	"github.com/stratumn/sdk/types"
 )
 
 const (
@@ -13,4 +14,5 @@ const (
 // Validator defines the interface with single Validate() method
 type Validator interface {
 	Validate(store.Reader, *cs.Segment) error
+	Hash() *types.Bytes32
 }

--- a/validator/validator_test.go
+++ b/validator/validator_test.go
@@ -229,6 +229,9 @@ func TestNewRootValidator(t *testing.T) {
 	if len(defaultRootValidator.(*rootValidator).ValidatorsByProcess) != 2 {
 		t.Errorf("fail to load root validator")
 	}
+	if validatorHash := defaultRootValidator.Hash(); validatorHash == nil {
+		t.Errorf("validator hash is empty")
+	}
 
 	if err := tmpfile.Close(); err != nil {
 		t.Error(err)

--- a/validator/validator_test.go
+++ b/validator/validator_test.go
@@ -242,6 +242,9 @@ func TestNewRootValidator(t *testing.T) {
 	if len(fileNotFoundRootValidator.(*rootValidator).ValidatorsByProcess) != 0 {
 		t.Errorf("fail to create root validator: file not found")
 	}
+	if validatorHash := fileNotFoundRootValidator.Hash(); validatorHash != nil {
+		t.Errorf("validator hash should be empty: got %v", validatorHash)
+	}
 }
 
 func TestRootValidator(t *testing.T) {


### PR DESCRIPTION
We currently don't provide a hash of the validations file used.
This is useful for the changes we want to do on TMPoP, where the validations hash will be part of the AppHash.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stratumn/sdk/260)
<!-- Reviewable:end -->
