### PR TITLE
ci: cache vendor directory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,9 @@ env:
   global:
   - COMMIT=${TRAVIS_COMMIT::8}
   - DOCKER_USER=stratumndocker
+cache:
+  directories:
+  - $GOPATH/pkg/dep
 
 before_install:
   - sudo service postgresql stop


### PR DESCRIPTION
Closes #269 

`dep ensure` takes about 10s now (used to take about 40s)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stratumn/sdk/272)
<!-- Reviewable:end -->
