### PR TITLE
types: add Equals utilities to Bytes32

### DIFF
--- a/cs/evidences/evidences.go
+++ b/cs/evidences/evidences.go
@@ -173,7 +173,7 @@ func (p *TendermintProof) Verify(linkHash interface{}) bool {
 
 	if len(p.Path) == 0 {
 		// If the tree contains a single element, it's valid if it's the root
-		if lh.Compare(p.Root) == 0 {
+		if lh.Equals(p.Root) {
 			return true
 		}
 
@@ -186,7 +186,7 @@ func (p *TendermintProof) Verify(linkHash interface{}) bool {
 
 	// And that the merkle path starts at the given link hash
 
-	if lh.Compare(&p.Path[0].Left) != 0 && lh.Compare(&p.Path[0].Right) != 0 {
+	if !lh.Equals(&p.Path[0].Left) && !lh.Equals(&p.Path[0].Right) {
 		return false
 	}
 

--- a/store/store.go
+++ b/store/store.go
@@ -303,7 +303,7 @@ func (filter SegmentFilter) MatchLink(link *cs.Link) bool {
 		lh, _ := link.Hash()
 		var match bool
 		for _, linkHash := range filter.LinkHashes {
-			if linkHash.Compare(lh) == 0 {
+			if linkHash.Equals(lh) {
 				match = true
 				break
 			}

--- a/tmpop/tmpop.go
+++ b/tmpop/tmpop.go
@@ -134,7 +134,7 @@ func (t *TMPop) Info(req abci.RequestInfo) abci.ResponseInfo {
 	// an empty byte slice (instead of a 32-byte array of 0)
 	// Otherwise handshake will not work
 	lastAppHash := []byte{}
-	if t.lastBlock.AppHash != nil && !t.lastBlock.AppHash.Zero() {
+	if !t.lastBlock.AppHash.Zero() {
 		lastAppHash = t.lastBlock.AppHash[:]
 	}
 

--- a/tmpop/tmpop.go
+++ b/tmpop/tmpop.go
@@ -134,7 +134,7 @@ func (t *TMPop) Info(req abci.RequestInfo) abci.ResponseInfo {
 	// an empty byte slice (instead of a 32-byte array of 0)
 	// Otherwise handshake will not work
 	lastAppHash := []byte{}
-	if t.lastBlock.AppHash != nil && t.lastBlock.AppHash.Compare(&types.Bytes32{}) != 0 {
+	if t.lastBlock.AppHash != nil && !t.lastBlock.AppHash.Zero() {
 		lastAppHash = t.lastBlock.AppHash[:]
 	}
 
@@ -163,7 +163,7 @@ func (t *TMPop) BeginBlock(req abci.RequestBeginBlock) {
 	// consensus has been formed around it.
 	// This AppHash will never be denied in a future block so we can add
 	// evidence to the links that were added in the previous blocks.
-	if t.lastBlock.AppHash.Compare(types.NewBytes32FromBytes(t.currentHeader.AppHash)) == 0 {
+	if t.lastBlock.AppHash.EqualsBytes(t.currentHeader.AppHash) {
 		t.addTendermintEvidence(req.Header)
 	} else {
 		log.Warnf("Unexpected AppHash in BeginBlock, got %x, expected %x",
@@ -389,7 +389,7 @@ func (t *TMPop) addTendermintEvidence(header *abci.Header) {
 	merkleRoot := merkle.Root()
 
 	appHash, err := ComputeAppHash(previousAppHash, validatorHash, merkleRoot)
-	if appHash.Compare(types.NewBytes32FromBytes(header.AppHash)) != 0 {
+	if !appHash.EqualsBytes(header.AppHash) {
 		log.Warnf("App hash %x doesn't match the header's: %x.\nEvidence will not be generated.",
 			*appHash,
 			header.AppHash)

--- a/tmpop/tmpoptestcases/lastblock.go
+++ b/tmpop/tmpoptestcases/lastblock.go
@@ -18,7 +18,6 @@ import (
 	"testing"
 
 	"github.com/stratumn/sdk/tmpop"
-	"github.com/stratumn/sdk/types"
 )
 
 // TestLastBlock tests if tmpop correctly stores information
@@ -42,7 +41,7 @@ func (f Factory) TestLastBlock(t *testing.T) {
 				got.Height, 2)
 		}
 
-		if got.AppHash.Compare(types.NewBytes32FromBytes(lastAppHash)) != 0 {
+		if !got.AppHash.EqualsBytes(lastAppHash) {
 			t.Errorf("a.Commit(): expected commit to save the last app hash, expected %v, got %v",
 				lastAppHash, got.AppHash)
 		}

--- a/tmpop/tmpoptestcases/query.go
+++ b/tmpop/tmpoptestcases/query.go
@@ -140,7 +140,7 @@ func (f Factory) TestQuery(t *testing.T) {
 		}
 
 		for _, segment := range gots {
-			if segment.GetLinkHash().Compare(invalidLinkHash) == 0 {
+			if segment.GetLinkHash().Equals(invalidLinkHash) {
 				t.Errorf("Invalid segment found in FindSegments")
 			}
 		}

--- a/types/types.go
+++ b/types/types.go
@@ -200,7 +200,42 @@ func (b *Bytes32) UnmarshalJSON(data []byte) error {
 
 // Compare compares two Bytes32
 func (b *Bytes32) Compare(b2 *Bytes32) int {
+	if b == nil || b2 == nil {
+		if b == nil && b2 == nil {
+			return 0
+		}
+
+		return 1
+	}
+
 	return bytes.Compare(b[:], b2[:])
+}
+
+// Equals checks if two Bytes32 are equal
+func (b *Bytes32) Equals(b2 *Bytes32) bool {
+	return b.Compare(b2) == 0
+}
+
+// EqualsBytes checks if a byte slice equals a Bytes32
+func (b *Bytes32) EqualsBytes(b2 []byte) bool {
+	if len(b2) == 0 && (b == nil || b.Zero()) {
+		return true
+	}
+
+	if b == nil {
+		return false
+	}
+
+	return bytes.Compare(b[:], b2) == 0
+}
+
+// Zero checks if a Bytes32 is the default value
+func (b *Bytes32) Zero() bool {
+	if b == nil {
+		return false
+	}
+
+	return b.Equals(&Bytes32{})
 }
 
 // Reverse reverses the bytes order.

--- a/types/types.go
+++ b/types/types.go
@@ -142,6 +142,9 @@ func (rb *ReversedBytes20) Reverse(b *Bytes20) {
 // Bytes32Size is the size of a 32-byte long byte array.
 const Bytes32Size = 32
 
+// Bytes32Zero is the default value for a 32-byte long byte array.
+var Bytes32Zero = &Bytes32{}
+
 // Bytes32 is a 32-byte long byte array.
 type Bytes32 [Bytes32Size]byte
 
@@ -200,8 +203,8 @@ func (b *Bytes32) UnmarshalJSON(data []byte) error {
 
 // Compare compares two Bytes32
 func (b *Bytes32) Compare(b2 *Bytes32) int {
-	if b == nil || b2 == nil {
-		if b == nil && b2 == nil {
+	if b.Zero() || b2.Zero() {
+		if b.Zero() && b2.Zero() {
 			return 0
 		}
 
@@ -218,7 +221,7 @@ func (b *Bytes32) Equals(b2 *Bytes32) bool {
 
 // EqualsBytes checks if a byte slice equals a Bytes32
 func (b *Bytes32) EqualsBytes(b2 []byte) bool {
-	if len(b2) == 0 && (b == nil || b.Zero()) {
+	if len(b2) == 0 && b.Zero() {
 		return true
 	}
 
@@ -229,13 +232,9 @@ func (b *Bytes32) EqualsBytes(b2 []byte) bool {
 	return bytes.Compare(b[:], b2) == 0
 }
 
-// Zero checks if a Bytes32 is the default value
+// Zero checks if a Bytes32 is the default value or nil
 func (b *Bytes32) Zero() bool {
-	if b == nil {
-		return false
-	}
-
-	return b.Equals(&Bytes32{})
+	return b == nil || bytes.Compare(b[:], Bytes32Zero[:]) == 0
 }
 
 // Reverse reverses the bytes order.

--- a/types/types_test.go
+++ b/types/types_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/stratumn/sdk/types"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestNewBytes20FromString(t *testing.T) {
@@ -315,6 +316,32 @@ func TestNewBytes32FromBytes_bigSlice(t *testing.T) {
 			t.Error("Invalid byte")
 		}
 	}
+}
+
+func TestBytes32Compare(t *testing.T) {
+	var nilBytes32 *types.Bytes32
+	zero := &types.Bytes32{}
+	nonZero, _ := types.NewBytes32FromString("1234567890123456789012345678901234567890123456789012345678901234")
+
+	t.Run("Nil slice is equal to zero", func(t *testing.T) {
+		assert.True(t, zero.EqualsBytes(nil))
+	})
+
+	t.Run("Empty slice is equal to zero", func(t *testing.T) {
+		assert.True(t, zero.EqualsBytes([]byte{}))
+	})
+
+	t.Run("Nil bytes32 is not zero", func(t *testing.T) {
+		assert.False(t, nilBytes32.Zero())
+	})
+
+	t.Run("Nil bytes32 comparison to zero", func(t *testing.T) {
+		assert.NotEqual(t, 0, nilBytes32.Compare(zero))
+	})
+
+	t.Run("Nil bytes32 comparison", func(t *testing.T) {
+		assert.NotEqual(t, 0, nilBytes32.Compare(nonZero))
+	})
 }
 
 func TestBytes32String(t *testing.T) {

--- a/types/types_test.go
+++ b/types/types_test.go
@@ -320,23 +320,22 @@ func TestNewBytes32FromBytes_bigSlice(t *testing.T) {
 
 func TestBytes32Compare(t *testing.T) {
 	var nilBytes32 *types.Bytes32
-	zero := &types.Bytes32{}
 	nonZero, _ := types.NewBytes32FromString("1234567890123456789012345678901234567890123456789012345678901234")
 
 	t.Run("Nil slice is equal to zero", func(t *testing.T) {
-		assert.True(t, zero.EqualsBytes(nil))
+		assert.True(t, types.Bytes32Zero.EqualsBytes(nil))
 	})
 
 	t.Run("Empty slice is equal to zero", func(t *testing.T) {
-		assert.True(t, zero.EqualsBytes([]byte{}))
+		assert.True(t, types.Bytes32Zero.EqualsBytes([]byte{}))
 	})
 
-	t.Run("Nil bytes32 is not zero", func(t *testing.T) {
-		assert.False(t, nilBytes32.Zero())
+	t.Run("Nil bytes32 is zero", func(t *testing.T) {
+		assert.True(t, nilBytes32.Zero())
 	})
 
 	t.Run("Nil bytes32 comparison to zero", func(t *testing.T) {
-		assert.NotEqual(t, 0, nilBytes32.Compare(zero))
+		assert.Equal(t, 0, nilBytes32.Compare(types.Bytes32Zero))
 	})
 
 	t.Run("Nil bytes32 comparison", func(t *testing.T) {


### PR DESCRIPTION
This helps readability.
I also think that most helper methods on Bytes32 should explicitly handle the nil types so that we don't get an ugly seg fault when we call them on a nil pointer.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stratumn/sdk/277)
<!-- Reviewable:end -->
