### PR TITLE
ci: fix docker repository

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ go:
 env:
   global:
   - COMMIT=${TRAVIS_COMMIT::8}
-  - DOCKER_USER=stratumndocker
+  - DOCKER_HUB_USER=stratumndocker
 cache:
   directories:
   - $GOPATH/pkg/dep
@@ -27,7 +27,7 @@ after_success:
 deploy:
   skip_cleanup: true
   provider: script
-  script: docker login --username $DOCKER_USER --password $DOCKER_PASS && CGO_ENABLED=0 make docker_images VERSION=$COMMIT && make docker_push VERSION=$COMMIT
+  script: docker login --username $DOCKER_HUB_USER --password $DOCKER_PASS && CGO_ENABLED=0 make docker_images VERSION=$COMMIT && make docker_push VERSION=$COMMIT
   on:
     go: 1.9
     branch: master


### PR DESCRIPTION
The Makefile uses the DOCKER_USER variable to select the repository
where images should be pushed. We uses to use this variable to define
the user of Docker Hub that can push images.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stratumn/sdk/278)
<!-- Reviewable:end -->
