### PR TITLE
cs: move validate and other utility methods from segment to link

### DIFF
--- a/bufferedbatch/batch.go
+++ b/bufferedbatch/batch.go
@@ -36,12 +36,11 @@ func NewBatch(a store.Adapter) *Batch {
 
 // CreateLink implements github.com/stratumn/sdk/store.LinkWriter.CreateLink.
 func (b *Batch) CreateLink(link *cs.Link) (*types.Bytes32, error) {
-	segment := link.Segmentify()
-	if err := segment.Validate(b.GetSegment); err != nil {
+	if err := link.Validate(b.GetSegment); err != nil {
 		return nil, err
 	}
 	b.Links = append(b.Links, link)
-	return segment.GetLinkHash(), nil
+	return link.Hash()
 }
 
 // GetSegment returns a segment from the cache or delegates the call to the store.

--- a/bufferedbatch/batch_test.go
+++ b/bufferedbatch/batch_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/stratumn/sdk/cs/cstesting"
 	"github.com/stratumn/sdk/store"
 	"github.com/stratumn/sdk/store/storetesting"
+	"github.com/stratumn/sdk/testutil"
 	"github.com/stratumn/sdk/types"
 )
 
@@ -99,7 +100,7 @@ func TestBatch_GetSegment(t *testing.T) {
 		t.Errorf("link = %v want %v", got, want)
 	}
 
-	segment, err = batch.GetSegment(cstesting.RandomSegment().GetLinkHash())
+	segment, err = batch.GetSegment(testutil.RandomHash())
 	if got, want := err, notFoundErr; got != want {
 		t.Errorf("GetSegment should return an error: %s want %s", got, want)
 	}

--- a/cs/cstesting/cstesting.go
+++ b/cs/cstesting/cstesting.go
@@ -50,19 +50,6 @@ func CreateLink(process, mapID, prevLinkHash string, tags []interface{}, priorit
 	return link
 }
 
-// CreateSegment creates a minimal segment.
-func CreateSegment(process, mapID, prevLinkHash string, tags []interface{}, priority float64) *cs.Segment {
-	link := CreateLink(process, mapID, prevLinkHash, tags, priority)
-	segment := &cs.Segment{
-		Link: *link,
-		Meta: cs.SegmentMeta{},
-	}
-
-	segment.SetLinkHash()
-
-	return segment
-}
-
 // RandomLink creates a random link.
 func RandomLink() *cs.Link {
 	return CreateLink(testutil.RandomString(24), testutil.RandomString(24),
@@ -82,12 +69,6 @@ func InvalidLinkWithProcess(process string) *cs.Link {
 		testutil.RandomHash().String(), RandomTags(), rand.Float64())
 }
 
-// RandomSegment creates a random segment.
-func RandomSegment() *cs.Segment {
-	return CreateSegment(testutil.RandomString(24), testutil.RandomString(24),
-		testutil.RandomHash().String(), RandomTags(), rand.Float64())
-}
-
 // RandomEvidence creates a random evidence.
 func RandomEvidence() *cs.Evidence {
 	return &cs.Evidence{
@@ -96,47 +77,22 @@ func RandomEvidence() *cs.Evidence {
 	}
 }
 
-// ChangeSegmentState clones a segment and randomly changes its state.
-func ChangeSegmentState(s *cs.Segment) *cs.Segment {
-	clone := CloneSegment(s)
-	clone.Link.State["random"] = testutil.RandomString(12)
-	clone.SetLinkHash()
-	return clone
-}
-
-// ChangeLinkState clones a link and randomly changes its state.
-func ChangeLinkState(l *cs.Link) *cs.Link {
-	clone := CloneLink(l)
+// ChangeState clones a link and randomly changes its state.
+func ChangeState(l *cs.Link) *cs.Link {
+	clone := Clone(l)
 	clone.State["random"] = testutil.RandomString(12)
 	return clone
 }
 
-// ChangeSegmentMapID clones a segment and randomly changes its map ID.
-func ChangeSegmentMapID(s *cs.Segment) *cs.Segment {
-	clone := CloneSegment(s)
-	clone.Link.Meta["mapId"] = testutil.RandomString(24)
-	clone.SetLinkHash()
-	return clone
-}
-
-// ChangeLinkMapID clones a link and randomly changes its map ID.
-func ChangeLinkMapID(l *cs.Link) *cs.Link {
-	clone := CloneLink(l)
+// ChangeMapID clones a link and randomly changes its map ID.
+func ChangeMapID(l *cs.Link) *cs.Link {
+	clone := Clone(l)
 	clone.Meta["mapId"] = testutil.RandomString(24)
 	return clone
 }
 
-// RandomBranch appends a random segment to a segment.
-func RandomBranch(s *cs.Segment) *cs.Segment {
-	branch := CreateSegment(testutil.RandomString(24), testutil.RandomString(24),
-		s.Meta.LinkHash, RandomTags(), rand.Float64())
-	branch.Link.Meta["mapId"] = s.Link.Meta["mapId"]
-	branch.SetLinkHash()
-	return branch
-}
-
-// RandomLinkBranch appends a random link to a link.
-func RandomLinkBranch(parent *cs.Link) *cs.Link {
+// RandomBranch appends a random link to a link.
+func RandomBranch(parent *cs.Link) *cs.Link {
 	linkHash, _ := parent.HashString()
 	branch := CreateLink(testutil.RandomString(24), testutil.RandomString(24),
 		linkHash, RandomTags(), rand.Float64())
@@ -153,24 +109,8 @@ func RandomTags() []interface{} {
 	return tags
 }
 
-// CloneSegment clones a segment.
-func CloneSegment(s *cs.Segment) *cs.Segment {
-	var clone cs.Segment
-
-	js, err := json.Marshal(s)
-	if err != nil {
-		panic(err)
-	}
-
-	if err := json.Unmarshal(js, &clone); err != nil {
-		panic(err)
-	}
-
-	return &clone
-}
-
-// CloneLink clones a link.
-func CloneLink(l *cs.Link) *cs.Link {
+// Clone clones a link.
+func Clone(l *cs.Link) *cs.Link {
 	var clone cs.Link
 
 	js, err := json.Marshal(l)

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -48,7 +48,7 @@ func init() {
 	segmentSlice = make(cs.SegmentSlice, sliceSize)
 	stringSlice = make([]string, sliceSize)
 	for i := 0; i < sliceSize; i++ {
-		segmentSlice[i] = cstesting.RandomSegment()
+		segmentSlice[i] = cstesting.RandomLink().Segmentify()
 		stringSlice[i] = testutil.RandomString(10)
 	}
 }

--- a/store/storehttp/storehttp.go
+++ b/store/storehttp/storehttp.go
@@ -222,15 +222,14 @@ func (s *Server) createLink(w http.ResponseWriter, r *http.Request, _ httprouter
 		return nil, jsonhttp.NewErrBadRequest(err.Error())
 	}
 
-	segment := link.Segmentify()
-	if err := segment.Validate(s.adapter.GetSegment); err != nil {
+	if err := link.Validate(s.adapter.GetSegment); err != nil {
 		return nil, jsonhttp.NewErrBadRequest(err.Error())
 	}
 	if _, err := s.adapter.CreateLink(&link); err != nil {
 		return nil, err
 	}
 
-	return segment, nil
+	return link.Segmentify(), nil
 }
 
 func (s *Server) addEvidence(w http.ResponseWriter, r *http.Request, p httprouter.Params) (interface{}, error) {

--- a/store/storehttp/storehttp_test.go
+++ b/store/storehttp/storehttp_test.go
@@ -222,7 +222,7 @@ func TestAddEvidence_err(t *testing.T) {
 
 func TestGetSegment(t *testing.T) {
 	s, a := createServer()
-	s1 := cstesting.RandomSegment()
+	s1 := cstesting.RandomLink().Segmentify()
 	a.MockGetSegment.Fn = func(*types.Bytes32) (*cs.Segment, error) { return s1, nil }
 
 	var s2 cs.Segment
@@ -298,7 +298,7 @@ func TestFindSegments(t *testing.T) {
 	s, a := createServer()
 	var s1 cs.SegmentSlice
 	for i := 0; i < 10; i++ {
-		s1 = append(s1, cstesting.RandomSegment())
+		s1 = append(s1, cstesting.RandomLink().Segmentify())
 	}
 	a.MockFindSegments.Fn = func(*store.SegmentFilter) (cs.SegmentSlice, error) { return s1, nil }
 
@@ -346,7 +346,7 @@ func TestFindSegments_multipleMapIDs(t *testing.T) {
 	s, a := createServer()
 	var s1 cs.SegmentSlice
 	for i := 0; i < 10; i++ {
-		s1 = append(s1, cstesting.RandomSegment())
+		s1 = append(s1, cstesting.RandomLink().Segmentify())
 	}
 	a.MockFindSegments.Fn = func(*store.SegmentFilter) (cs.SegmentSlice, error) { return s1, nil }
 
@@ -396,7 +396,7 @@ func TestFindSegments_defaultLimit(t *testing.T) {
 	s, a := createServer()
 	var s1 cs.SegmentSlice
 	for i := 0; i < 2; i++ {
-		s1 = append(s1, cstesting.RandomSegment())
+		s1 = append(s1, cstesting.RandomLink().Segmentify())
 	}
 	a.MockFindSegments.Fn = func(*store.SegmentFilter) (cs.SegmentSlice, error) { return s1, nil }
 

--- a/store/storetestcases/createlink.go
+++ b/store/storetestcases/createlink.go
@@ -59,7 +59,7 @@ func (f Factory) TestCreateLinkUpdatedState(t *testing.T) {
 		t.Fatalf("a.CreateLink(): err: %s", err)
 	}
 
-	l = cstesting.ChangeLinkState(l)
+	l = cstesting.ChangeState(l)
 	if _, err := a.CreateLink(l); err != nil {
 		t.Fatalf("a.CreateLink(): err: %s", err)
 	}
@@ -76,7 +76,7 @@ func (f Factory) TestCreateLinkUpdatedMapID(t *testing.T) {
 		t.Fatalf("a.CreateLink(): err: %s", err)
 	}
 
-	l2 := cstesting.ChangeLinkMapID(l1)
+	l2 := cstesting.ChangeMapID(l1)
 	if _, err := a.CreateLink(l2); err != nil {
 		t.Fatalf("a.CreateLink(): err: %s", err)
 	}
@@ -93,7 +93,7 @@ func (f Factory) TestCreateLinkBranch(t *testing.T) {
 		t.Fatalf("a.CreateLink(): err: %s", err)
 	}
 
-	l = cstesting.RandomLinkBranch(l)
+	l = cstesting.RandomBranch(l)
 	if _, err := a.CreateLink(l); err != nil {
 		t.Fatalf("a.CreateLink(): err: %s", err)
 	}

--- a/store/storetestcases/findsegments.go
+++ b/store/storetestcases/findsegments.go
@@ -44,7 +44,7 @@ func createRandomLink(adapter *store.Adapter, prepareLink func(l *cs.Link)) *cs.
 }
 
 func createLinkBranch(adapter *store.Adapter, parent *cs.Link, prepareLink func(l *cs.Link)) *cs.Link {
-	return createLink(adapter, cstesting.RandomLinkBranch(parent), prepareLink)
+	return createLink(adapter, cstesting.RandomBranch(parent), prepareLink)
 }
 
 // TestFindSegments tests what happens when you search with default pagination.

--- a/store/storetestcases/getsegment.go
+++ b/store/storetestcases/getsegment.go
@@ -62,7 +62,7 @@ func (f Factory) TestGetSegmentUpdatedState(t *testing.T) {
 
 	l1 := cstesting.RandomLink()
 	linkHash1, _ := a.CreateLink(l1)
-	l2 := cstesting.ChangeLinkState(l1)
+	l2 := cstesting.ChangeState(l1)
 	a.CreateLink(l2)
 
 	got, err := a.GetSegment(linkHash1)
@@ -89,7 +89,7 @@ func (f Factory) TestGetSegmentUpdatedMapID(t *testing.T) {
 
 	l1 := cstesting.RandomLink()
 	linkHash1, _ := a.CreateLink(l1)
-	l2 := cstesting.ChangeLinkMapID(l1)
+	l2 := cstesting.ChangeMapID(l1)
 	a.CreateLink(l2)
 
 	got, err := a.GetSegment(linkHash1)

--- a/store/storetesting/mockadapter_test.go
+++ b/store/storetesting/mockadapter_test.go
@@ -104,7 +104,7 @@ func TestMockAdapter_GetSegment(t *testing.T) {
 		t.Fatalf("a.GetSegment(): err: %s", err)
 	}
 
-	s1 := cstesting.RandomSegment()
+	s1 := cstesting.RandomLink().Segmentify()
 	a.MockGetSegment.Fn = func(linkHash *types.Bytes32) (*cs.Segment, error) { return s1, nil }
 	linkHash2 := testutil.RandomHash()
 	s2, err := a.GetSegment(linkHash2)
@@ -136,7 +136,7 @@ func TestMockAdapter_FindSegments(t *testing.T) {
 		t.Fatalf("a.FindSegments(): err: %s", err)
 	}
 
-	s := cstesting.RandomSegment()
+	s := cstesting.RandomLink().Segmentify()
 	a.MockFindSegments.Fn = func(*store.SegmentFilter) (cs.SegmentSlice, error) { return cs.SegmentSlice{s}, nil }
 	prevLinkHash := testutil.RandomHash().String()
 	f := store.SegmentFilter{PrevLinkHash: &prevLinkHash}

--- a/tmpop/state.go
+++ b/tmpop/state.go
@@ -75,7 +75,7 @@ func (s *State) Deliver(link *cs.Link) abci.Result {
 }
 
 func (s *State) checkLinkAndAddToBatch(link *cs.Link, batch store.Batch) abci.Result {
-	err := link.Segmentify().Validate(batch.GetSegment)
+	err := link.Validate(batch.GetSegment)
 	if err != nil {
 		return abci.NewError(
 			CodeTypeValidation,


### PR DESCRIPTION
At last, we can clean up many operations that conceptually acted on Links but were defined on Segment.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stratumn/sdk/285)
<!-- Reviewable:end -->
