### PR TITLE
tmpop: deliver events via abci query

### DIFF
--- a/tmpop/query.go
+++ b/tmpop/query.go
@@ -18,12 +18,13 @@ import "encoding/json"
 
 // Query types.
 const (
-	AddEvidence  = "AddEvidence"
-	FindSegments = "FindSegments"
-	GetEvidences = "GetEvidences"
-	GetInfo      = "GetInfo"
-	GetMapIDs    = "GetMapIDs"
-	GetSegment   = "GetSegment"
+	AddEvidence   = "AddEvidence"
+	FindSegments  = "FindSegments"
+	GetEvidences  = "GetEvidences"
+	GetInfo       = "GetInfo"
+	GetMapIDs     = "GetMapIDs"
+	GetSegment    = "GetSegment"
+	PendingEvents = "PendingEvents"
 )
 
 // BuildQueryBinary outputs the marshalled Query.

--- a/tmpop/tmClient.go
+++ b/tmpop/tmClient.go
@@ -18,12 +18,10 @@ import (
 	log "github.com/sirupsen/logrus"
 	abci "github.com/tendermint/abci/types"
 	"github.com/tendermint/tendermint/rpc/client"
-	events "github.com/tendermint/tmlibs/events"
 )
 
 // TendermintClient is a light interface to query Tendermint Core
 type TendermintClient interface {
-	FireEvent(event string, data events.EventData)
 	Block(height int) *Block
 }
 
@@ -43,11 +41,6 @@ func NewTendermintClient(tmClient client.Client) *TendermintClientWrapper {
 	return &TendermintClientWrapper{
 		tmClient: tmClient,
 	}
-}
-
-// FireEvent fires an event through Tendermint Core
-func (c *TendermintClientWrapper) FireEvent(event string, data events.EventData) {
-	c.tmClient.FireEvent(event, data)
 }
 
 // Block queries for a block at a specific height

--- a/tmpop/tmpoptestcases/mocks/mock_tmclient.go
+++ b/tmpop/tmpoptestcases/mocks/mock_tmclient.go
@@ -17,7 +17,6 @@ package tmpoptestcasesmocks
 import (
 	"github.com/stratumn/sdk/tmpop"
 	"github.com/stretchr/testify/mock"
-	events "github.com/tendermint/tmlibs/events"
 )
 
 // MockedTendermintClient is a mock for the tmpop.TendermintClient interface
@@ -27,13 +26,7 @@ type MockedTendermintClient struct {
 
 // AllowCalls allows any call to go through the mock without throwing errors
 func (m *MockedTendermintClient) AllowCalls() {
-	m.On("FireEvent", mock.Anything, mock.Anything)
 	m.On("Block", mock.Anything)
-}
-
-// FireEvent mocks firing an event to Tendermint
-func (m *MockedTendermintClient) FireEvent(event string, data events.EventData) {
-	m.Called(event, data)
 }
 
 // Block returns an empty block

--- a/tmstore/tmstore.go
+++ b/tmstore/tmstore.go
@@ -31,6 +31,7 @@ import (
 	abci "github.com/tendermint/abci/types"
 	"github.com/tendermint/tendermint/rpc/client"
 	ctypes "github.com/tendermint/tendermint/rpc/core/types"
+	tmtypes "github.com/tendermint/tendermint/types"
 	"github.com/tendermint/tmlibs/events"
 
 	log "github.com/sirupsen/logrus"
@@ -101,8 +102,8 @@ func (t *TMStore) StartWebsocket() error {
 	}
 
 	// TMPoP notifies us of store events that we forward to clients
-	t.tmClient.AddListenerForEvent("TMStore", tmpop.StoreEvents, func(msg events.EventData) {
-		go t.notifyStoreChans(msg)
+	t.tmClient.AddListenerForEvent("TMStore", tmtypes.EventStringNewBlock(), func(_ events.EventData) {
+		go t.notifyStoreChans()
 	})
 
 	log.Info("Connected to TMPoP")
@@ -131,14 +132,24 @@ func (t *TMStore) StopWebsocket() {
 	t.tmClient.Stop()
 }
 
-func (t *TMStore) notifyStoreChans(msg events.EventData) {
-	storeEvent, ok := msg.(tmpop.StoreEventsData)
-	if !ok {
-		log.Debug("Event could not be read as a store event")
+func (t *TMStore) notifyStoreChans() {
+	var pendingEvents []*store.Event
+	response, err := t.sendQuery(tmpop.PendingEvents, nil)
+	if err != nil || response.Value == nil {
+		log.Warn("Could not get pending events from TMPoP.")
 	}
 
-	for _, c := range t.storeEventChans {
-		c <- storeEvent.StoreEvent
+	err = json.Unmarshal(response.Value, &pendingEvents)
+	if err != nil {
+		log.Warn("TMPoP pending events could not be unmarshalled.")
+	}
+
+	if len(pendingEvents) > 0 {
+		for _, event := range pendingEvents {
+			for _, c := range t.storeEventChans {
+				c <- event
+			}
+		}
 	}
 }
 

--- a/tmstore/tmstore.go
+++ b/tmstore/tmstore.go
@@ -144,11 +144,9 @@ func (t *TMStore) notifyStoreChans() {
 		log.Warn("TMPoP pending events could not be unmarshalled.")
 	}
 
-	if len(pendingEvents) > 0 {
-		for _, event := range pendingEvents {
-			for _, c := range t.storeEventChans {
-				c <- event
-			}
+	for _, event := range pendingEvents {
+		for _, c := range t.storeEventChans {
+			c <- event
 		}
 	}
 }


### PR DESCRIPTION
The FireEvent method on Tendermint Client was in fact not meant to be used by the ABCI.
After discussing this with the Tendermint team, an ok solution is to store pending events in tmpop and deliver them through an abci query.
Tendermint will maybe support ways for us to notify connected clients directly in the future, but meanwhile this is a good solution (even though I don't find it very elegant).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stratumn/sdk/291)
<!-- Reviewable:end -->
