### PR TITLE
tendermint: update to 0.13.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ services:
   - docker
 go:
   - 1.9
-  - tip
 env:
   global:
   - COMMIT=${TRAVIS_COMMIT::8}

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -117,8 +117,8 @@
 [[projects]]
   name = "github.com/gogo/protobuf"
   packages = ["gogoproto","jsonpb","proto","protoc-gen-gogo/descriptor","sortkeys","types"]
-  revision = "100ba4e885062801d56799d78530b73b178a78f3"
-  version = "v0.4"
+  revision = "342cbe0a04158f6dcb03ca0079991a51a4248c02"
+  version = "v0.5"
 
 [[projects]]
   branch = "master"
@@ -368,7 +368,7 @@
 
 [[projects]]
   name = "github.com/tendermint/tmlibs"
-  packages = ["autofile","cli/flags","clist","common","db","events","flowrate","log","merkle","pubsub","pubsub/query"]
+  packages = ["autofile","cli/flags","clist","common","db","flowrate","log","merkle","pubsub","pubsub/query"]
   revision = "bfcc0217f120d3bee6730ba0789d2eb72fc2e889"
   version = "v0.5.0"
 

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -471,6 +471,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "7c53caf303ae5ef35c261479fa9dba180ced1b9efb8ea6112f8fb046f5d16113"
+  inputs-digest = "7793c5d193a26dd68987b2de4a3ad02b05a1a840b411f38c462dc0a30185c8c6"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -23,7 +23,7 @@
   branch = "master"
   name = "github.com/btcsuite/btcd"
   packages = ["btcec","chaincfg","chaincfg/chainhash","txscript","wire"]
-  revision = "4803a8291c92a1d2d41041b942a9a9e37deab065"
+  revision = "2e60448ffcc6bf78332d1fe590260095f554dd78"
 
 [[projects]]
   branch = "master"
@@ -87,8 +87,8 @@
 [[projects]]
   name = "github.com/go-kit/kit"
   packages = ["log","log/level","log/term"]
-  revision = "a9ca6725cbbea455e61c6bc8a1ed28e81eb3493b"
-  version = "v0.5.0"
+  revision = "4dc7be5d2d12881735283bcab7352178e190fc71"
+  version = "v0.6.0"
 
 [[projects]]
   name = "github.com/go-logfmt/logfmt"
@@ -99,8 +99,8 @@
 [[projects]]
   name = "github.com/go-playground/locales"
   packages = [".","currency"]
-  revision = "b860c92274dfb72f517b8b4c11c6d9f2f8cc9d91"
-  version = "v0.11.1"
+  revision = "e4cbcb5d0652150d40ad0646651076b6bd2be4f6"
+  version = "v0.11.2"
 
 [[projects]]
   name = "github.com/go-playground/universal-translator"
@@ -111,12 +111,12 @@
 [[projects]]
   name = "github.com/go-stack/stack"
   packages = ["."]
-  revision = "817915b46b97fd7bb80e8ab6b69f01a53ac3eebf"
-  version = "v1.6.0"
+  revision = "259ab82a6cad3992b4e21ff5cac294ccb06474bc"
+  version = "v1.7.0"
 
 [[projects]]
   name = "github.com/gogo/protobuf"
-  packages = ["proto"]
+  packages = ["gogoproto","jsonpb","proto","protoc-gen-gogo/descriptor","sortkeys","types"]
   revision = "100ba4e885062801d56799d78530b73b178a78f3"
   version = "v0.4"
 
@@ -130,7 +130,7 @@
   branch = "master"
   name = "github.com/golang/protobuf"
   packages = ["proto","ptypes","ptypes/any","ptypes/duration","ptypes/timestamp"]
-  revision = "130e6b02ab059e7b717a096f397c5b60111cae74"
+  revision = "1e59b77b52bf8e4b449a57e6f79f21226d571845"
 
 [[projects]]
   branch = "master"
@@ -142,7 +142,7 @@
   branch = "master"
   name = "github.com/google/go-github"
   packages = ["github"]
-  revision = "511f540f1887d30b88cee4a2fcd1f2922754acf4"
+  revision = "fbfee053c26dab3772adfc7799d995eed379133e"
 
 [[projects]]
   branch = "master"
@@ -177,8 +177,8 @@
 [[projects]]
   branch = "master"
   name = "github.com/hashicorp/hcl"
-  packages = [".","hcl/ast","hcl/parser","hcl/scanner","hcl/strconv","hcl/token","json/parser","json/scanner","json/token"]
-  revision = "68e816d1c783414e79bc65b3994d9ab6b0a722ab"
+  packages = [".","hcl/ast","hcl/parser","hcl/printer","hcl/scanner","hcl/strconv","hcl/token","json/parser","json/scanner","json/token"]
+  revision = "23c074d0eceb2b8a5bfdbb271ab780cde70f05a8"
 
 [[projects]]
   name = "github.com/inconshreveable/mousetrap"
@@ -232,7 +232,7 @@
   branch = "master"
   name = "github.com/mitchellh/mapstructure"
   packages = ["."]
-  revision = "d0303fe809921458f417bcf828397a65db30a7e4"
+  revision = "06020f85339e21b2478f756a78e295255ffa4d6a"
 
 [[projects]]
   name = "github.com/opencontainers/go-digest"
@@ -247,16 +247,10 @@
   version = "v1.0.1"
 
 [[projects]]
-  name = "github.com/pelletier/go-buffruneio"
-  packages = ["."]
-  revision = "c37440a7cf42ac63b919c752ca73a85067e05992"
-  version = "v0.2.0"
-
-[[projects]]
   name = "github.com/pelletier/go-toml"
   packages = ["."]
-  revision = "5ccdfb18c776b740aecaf085c4d9a2779199c279"
-  version = "v1.0.0"
+  revision = "16398bac157da96aa88f98a2df640c7f32af1da2"
+  version = "v1.0.1"
 
 [[projects]]
   name = "github.com/pkg/errors"
@@ -274,19 +268,19 @@
   branch = "master"
   name = "github.com/rcrowley/go-metrics"
   packages = ["."]
-  revision = "1f30fe9094a513ce4c700b9a54458bbb0c96996c"
+  revision = "e181e095bae94582363434144c61a9653aff6e50"
 
 [[projects]]
   name = "github.com/sirupsen/logrus"
   packages = ["."]
-  revision = "f006c2ac4710855cf0f916dd6b77acf6b048dc6e"
-  version = "v1.0.3"
+  revision = "d682213848ed68c0a260ca37d6dd5ace8423f5ba"
+  version = "v1.0.4"
 
 [[projects]]
-  branch = "master"
   name = "github.com/spf13/afero"
   packages = [".","mem"]
-  revision = "ee1bd8ee15a1306d1f9201acc41ef39cd9f99a1b"
+  revision = "8d919cbe7e2627e417f3e45c3c0e489a5b7e2536"
+  version = "v1.0.0"
 
 [[projects]]
   name = "github.com/spf13/cast"
@@ -298,7 +292,7 @@
   branch = "master"
   name = "github.com/spf13/cobra"
   packages = ["."]
-  revision = "b78744579491c1ceeaaa3b40205e56b0591b93a3"
+  revision = "ccaecb155a2177302cb56cae929251a256d0f646"
 
 [[projects]]
   branch = "master"
@@ -316,7 +310,7 @@
   branch = "master"
   name = "github.com/spf13/viper"
   packages = ["."]
-  revision = "8ef37cbca71638bf32f3d5e194117d4cb46da163"
+  revision = "1a0c4a370c3e8286b835467d2dfcdaf636c3538b"
 
 [[projects]]
   branch = "master"
@@ -334,31 +328,31 @@
   branch = "master"
   name = "github.com/syndtr/goleveldb"
   packages = ["leveldb","leveldb/cache","leveldb/comparer","leveldb/errors","leveldb/filter","leveldb/iterator","leveldb/journal","leveldb/memdb","leveldb/opt","leveldb/storage","leveldb/table","leveldb/util"]
-  revision = "b89cc31ef7977104127d34c1bd31ebd1a9db2199"
+  revision = "3d8f4155ffd9029d32e5cf03853b58759b6e3710"
 
 [[projects]]
   name = "github.com/tendermint/abci"
-  packages = ["client","example/dummy","types"]
-  revision = "76ef8a0697c6179220a74c479b36c27a5b53008a"
-  version = "v0.7.1"
+  packages = ["client","example/code","example/dummy","types"]
+  revision = "fca2b508c185b855af1446ec4afc19bdfc7b315d"
+  version = "v0.8.0"
 
 [[projects]]
   branch = "master"
   name = "github.com/tendermint/ed25519"
   packages = [".","edwards25519","extra25519"]
-  revision = "1f52c6f8b8a5c7908aff4497c186af344b428925"
+  revision = "d8387025d2b9d158cf4efb07e7ebf814bcce2057"
 
 [[projects]]
   name = "github.com/tendermint/go-crypto"
   packages = ["."]
-  revision = "311e8c1bf00fa5868daad4f8ea56dcad539182c0"
-  version = "v0.3.0"
+  revision = "dd20358a264c772b4a83e477b0cfce4c88a7001d"
+  version = "v0.4.1"
 
 [[projects]]
   name = "github.com/tendermint/go-wire"
-  packages = [".","data"]
-  revision = "2baffcb6b690057568bc90ef1d457efb150b979a"
-  version = "v0.7.1"
+  packages = [".","data","nowriter/tmlegacy"]
+  revision = "b6fc872b42d41158a60307db4da051dd6f179415"
+  version = "v0.7.2"
 
 [[projects]]
   name = "github.com/tendermint/iavl"
@@ -368,15 +362,15 @@
 
 [[projects]]
   name = "github.com/tendermint/tendermint"
-  packages = ["blockchain","config","consensus","consensus/types","mempool","node","p2p","p2p/upnp","proxy","rpc/client","rpc/core","rpc/core/types","rpc/grpc","rpc/lib","rpc/lib/client","rpc/lib/server","rpc/lib/types","rpc/test","state","state/txindex","state/txindex/kv","state/txindex/null","types","version"]
-  revision = "e236302256b8b0b75441e8e44c6d0d3f5b5152c6"
-  version = "v0.12.0"
+  packages = ["blockchain","config","consensus","consensus/types","mempool","node","p2p","p2p/trust","p2p/upnp","proxy","rpc/client","rpc/core","rpc/core/types","rpc/grpc","rpc/lib","rpc/lib/client","rpc/lib/server","rpc/lib/types","rpc/test","state","state/txindex","state/txindex/kv","state/txindex/null","types","version"]
+  revision = "88f5f21dbbf55589680d5e832647f5869f4fda1a"
+  version = "v0.14.0"
 
 [[projects]]
   name = "github.com/tendermint/tmlibs"
-  packages = ["autofile","cli/flags","clist","common","db","events","flowrate","log","merkle"]
-  revision = "d9525c0fb671204450b160807480e1263053fb20"
-  version = "v0.4.0"
+  packages = ["autofile","cli/flags","clist","common","db","events","flowrate","log","merkle","pubsub","pubsub/query"]
+  revision = "bfcc0217f120d3bee6730ba0789d2eb72fc2e889"
+  version = "v0.5.0"
 
 [[projects]]
   branch = "master"
@@ -394,37 +388,37 @@
   branch = "master"
   name = "github.com/xeipuuv/gojsonschema"
   packages = ["."]
-  revision = "3f523f4c14b6e925da10475eb0447c2f28614aac"
+  revision = "212d8a0df7acfab8bdd190a7a69f0ab7376edcc8"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/crypto"
   packages = ["cast5","curve25519","nacl/box","nacl/secretbox","openpgp","openpgp/armor","openpgp/elgamal","openpgp/errors","openpgp/packet","openpgp/s2k","pbkdf2","poly1305","ripemd160","salsa20/salsa","ssh/terminal"]
-  revision = "76eec36fa14229c4b25bb894c2d0e591527af429"
+  revision = "94eea52f7b742c7cbe0b03b22f0c4c8631ece122"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/net"
   packages = ["context","context/ctxhttp","http2","http2/hpack","idna","internal/timeseries","lex/httplex","proxy","trace"]
-  revision = "0a9397675ba34b2845f758fe3cd68828369c6517"
+  revision = "d866cfc389cec985d6fda2859936a575a55a3ab6"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/oauth2"
   packages = [".","internal"]
-  revision = "bb50c06baba3d0c76f9d125c0719093e315b5b44"
+  revision = "e585185218a1268736da499ab73c9a930e94a2a3"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/sys"
   packages = ["unix","windows"]
-  revision = "314a259e304ff91bd6985da2a7149bbf91237993"
+  revision = "53aa286056ef226755cd898109dbcdaba8ac0b81"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/text"
   packages = ["collate","collate/build","internal/colltab","internal/gen","internal/tag","internal/triegen","internal/ucd","language","secure/bidirule","transform","unicode/bidi","unicode/cldr","unicode/norm","unicode/rangetable"]
-  revision = "1cbadb444a806fd9430d14ad08967ed91da4fa0a"
+  revision = "3b24cac7bc3a458991ab409aa2a339ac9e0d60d6"
 
 [[projects]]
   name = "google.golang.org/appengine"
@@ -436,13 +430,13 @@
   branch = "master"
   name = "google.golang.org/genproto"
   packages = ["googleapis/rpc/status"]
-  revision = "1e559d0a00eef8a9a43151db4665280bd8dd5886"
+  revision = "73cb5d0be5af113b42057925bd6c93e3cd9f60fd"
 
 [[projects]]
   name = "google.golang.org/grpc"
-  packages = [".","codes","connectivity","credentials","grpclb/grpc_lb_v1/messages","grpclog","internal","keepalive","metadata","naming","peer","stats","status","tap","transport"]
-  revision = "f92cdcd7dcdc69e81b2d7b338479a19a8723cfa3"
-  version = "v1.6.0"
+  packages = [".","balancer","balancer/roundrobin","codes","connectivity","credentials","encoding","grpclb/grpc_lb_v1/messages","grpclog","internal","keepalive","metadata","naming","peer","resolver","resolver/dns","resolver/manual","resolver/passthrough","stats","status","tap","transport"]
+  revision = "be077907e29fdb945d351e4284eb5361e7f8924e"
+  version = "v1.8.1"
 
 [[projects]]
   name = "gopkg.in/dancannon/gorethink.v3"
@@ -459,8 +453,8 @@
 [[projects]]
   name = "gopkg.in/go-playground/validator.v9"
   packages = ["."]
-  revision = "a021b2ec9a8a8bb970f3f15bc42617cb520e8a64"
-  version = "v9.7.0"
+  revision = "61caf9d3038e1af346dbf5c2e16f6678e1548364"
+  version = "v9.9.0"
 
 [[projects]]
   name = "gopkg.in/gorethink/gorethink.v3"
@@ -472,7 +466,7 @@
   branch = "v2"
   name = "gopkg.in/yaml.v2"
   packages = ["."]
-  revision = "eb3733d160e74a9c7e442f435eb3bea458e1d19f"
+  revision = "287cf08546ab5e7e37d55a84f7ed3fd1db036de5"
 
 [solve-meta]
   analyzer-name = "dep"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -363,8 +363,8 @@
 [[projects]]
   name = "github.com/tendermint/tendermint"
   packages = ["blockchain","config","consensus","consensus/types","mempool","node","p2p","p2p/trust","p2p/upnp","proxy","rpc/client","rpc/core","rpc/core/types","rpc/grpc","rpc/lib","rpc/lib/client","rpc/lib/server","rpc/lib/types","rpc/test","state","state/txindex","state/txindex/kv","state/txindex/null","types","version"]
-  revision = "88f5f21dbbf55589680d5e832647f5869f4fda1a"
-  version = "v0.14.0"
+  revision = "a2b92c07453f66277f70d0c3979a9dac67bbecea"
+  version = "v0.13.0"
 
 [[projects]]
   name = "github.com/tendermint/tmlibs"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -36,7 +36,7 @@
 
 [[constraint]]
   name = "github.com/tendermint/abci"
-  version = "0.7.1"
+  version = "0.8.0"
 
 [[constraint]]
   branch = "master"
@@ -44,15 +44,15 @@
 
 [[constraint]]
   name = "github.com/tendermint/go-wire"
-  version = "0.7.1"
+  version = "0.7.2"
 
 [[constraint]]
   name = "github.com/tendermint/tendermint"
-  version = "0.12.0"
+  version = "0.14.0"
 
 [[constraint]]
   name = "github.com/tendermint/tmlibs"
-  version = "0.4.0"
+  version = "0.5.0"
 
 [[constraint]]
   branch = "master"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -77,3 +77,9 @@
 [[constraint]]
   name = "github.com/google/go-querystring"
   branch="master"
+
+[[override]] 
+  # This is required because Tendermint needs v0.5
+  # but Docker claims it needs v0.4 (but probably not intentionnally)
+  name = "github.com/gogo/protobuf"
+  version = "v0.5"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -48,7 +48,7 @@
 
 [[constraint]]
   name = "github.com/tendermint/tendermint"
-  version = "0.14.0"
+  version = "0.13.0"
 
 [[constraint]]
   name = "github.com/tendermint/tmlibs"

--- a/cmd/tmstore/main.go
+++ b/cmd/tmstore/main.go
@@ -22,6 +22,7 @@ import (
 	_ "github.com/stratumn/sdk/cs/evidences"
 	"github.com/stratumn/sdk/store/storehttp"
 	"github.com/stratumn/sdk/tmstore"
+	"github.com/tendermint/tendermint/rpc/client"
 )
 
 var (
@@ -39,7 +40,14 @@ func main() {
 	flag.Parse()
 	log.Infof("%s v%s@%s", tmstore.Description, version, commit[:7])
 
-	a := tmstore.New(&tmstore.Config{Endpoint: *endpoint, Version: version, Commit: commit})
+	tmClient := client.NewHTTP(*endpoint, "/websocket")
+	a := tmstore.New(
+		&tmstore.Config{
+			Version: version,
+			Commit:  commit,
+		},
+		tmClient)
+
 	go a.RetryStartWebsocket(*tmWsRetryInterval)
 
 	storehttp.RunWithFlags(a)

--- a/cs/evidence_test.go
+++ b/cs/evidence_test.go
@@ -30,7 +30,7 @@ import (
 )
 
 const (
-	height      = uint64(1)
+	height      = int64(1)
 	TestChainId = "testChain"
 )
 
@@ -214,7 +214,7 @@ func TestTendermintProof(t *testing.T) {
 
 	t.Run("Time()", func(t *testing.T) {
 		e := &evidences.TendermintProof{
-			Header: abci.Header{Time: uint64(42)},
+			Header: abci.Header{Time: int64(42)},
 		}
 
 		assert.Equal(t, uint64(42), e.Time(), "Invalid proof time")
@@ -222,8 +222,8 @@ func TestTendermintProof(t *testing.T) {
 
 	t.Run("FullProof()", func(t *testing.T) {
 		e := &evidences.TendermintProof{
-			BlockHeight:     uint64(42),
-			Header:          abci.Header{Time: uint64(42)},
+			BlockHeight:     int64(42),
+			Header:          abci.Header{Time: int64(42)},
 			ValidationsHash: testutil.RandomHash(),
 		}
 

--- a/cs/evidences/evidences.go
+++ b/cs/evidences/evidences.go
@@ -107,7 +107,7 @@ type TendermintSignature struct {
 
 // TendermintProof implements the Proof interface
 type TendermintProof struct {
-	BlockHeight uint64 `json:"blockHeight"`
+	BlockHeight int64 `json:"blockHeight"`
 
 	Root            *types.Bytes32 `json:"merkleRoot"`
 	Path            types.Path     `json:"merklePath"`
@@ -126,7 +126,7 @@ type TendermintProof struct {
 
 // Time returns the timestamp from the block header
 func (p *TendermintProof) Time() uint64 {
-	return p.Header.GetTime()
+	return uint64(p.Header.GetTime())
 }
 
 // FullProof returns a JSON formatted proof

--- a/tendermint/cmd.go
+++ b/tendermint/cmd.go
@@ -79,9 +79,10 @@ func RegisterFlags() {
 	flag.StringVar(&profLaddr, "prof_laddr", config.BaseConfig.ProfListenAddress, "Profile listen address")
 	flag.BoolVar(&fastSync, "fast_sync", config.BaseConfig.FastSync, "Fast blockchain syncing")
 	flag.BoolVar(&filterPeers, "filter_peers", config.BaseConfig.FilterPeers, "If true, query the ABCI app on connecting to a new peer so the app can decide if we should keep the connection or not")
-	flag.StringVar(&txIndex, "tx_index", config.BaseConfig.TxIndex, "What indexer to use for transactions")
 	flag.StringVar(&dbBackend, "db_backend", config.BaseConfig.DBBackend, "Database backend for the blockchain and TendermintCore state (leveldb or memdb)")
 	flag.StringVar(&dbDir, "db_dir", config.BaseConfig.DBPath, "Database directory")
+
+	flag.StringVar(&txIndex, "tx_index", config.TxIndex.Indexer, "What indexer to use for transactions")
 
 	flag.StringVar(&nodeLaddr, "node_laddr", config.P2P.ListenAddress, "Node listen address (0.0.0.0:0 means any interface, any port)")
 	flag.StringVar(&seeds, "seeds", config.P2P.Seeds, "Comma delimited host:port seed nodes")
@@ -141,9 +142,10 @@ func GetConfig() *cfg.Config {
 	config.BaseConfig.ProfListenAddress = profLaddr
 	config.BaseConfig.FastSync = fastSync
 	config.BaseConfig.FilterPeers = filterPeers
-	config.BaseConfig.TxIndex = txIndex
 	config.BaseConfig.DBBackend = dbBackend
 	config.BaseConfig.DBPath = dbDir
+
+	config.TxIndex.Indexer = txIndex
 
 	config.P2P.ListenAddress = nodeLaddr
 	config.P2P.Seeds = seeds

--- a/tmpop/data.go
+++ b/tmpop/data.go
@@ -63,7 +63,7 @@ func getValidatorHashKey(height int64) []byte {
 func (t *TMPop) saveValidatorHash() error {
 	if t.state.validator != nil {
 		key := getValidatorHashKey(t.currentHeader.Height)
-		value := (*t.state.validator).Hash()[:]
+		value := t.state.validator.Hash()[:]
 		if err := t.kvDB.SetValue(key, value); err != nil {
 			return err
 		}

--- a/tmpop/data.go
+++ b/tmpop/data.go
@@ -54,7 +54,7 @@ func saveLastBlock(a store.KeyValueWriter, l LastBlock) {
 	a.SetValue(tmpopLastBlockKey, wire.BinaryBytes(l))
 }
 
-func getValidatorHashKey(height uint64) []byte {
+func getValidatorHashKey(height int64) []byte {
 	key := fmt.Sprintf("tmpop:validator:%d", height)
 	return []byte(key)
 }
@@ -73,7 +73,7 @@ func (t *TMPop) saveValidatorHash() error {
 }
 
 // getValidatorHash gets the hash of the validator used for a block at a specific height
-func (t *TMPop) getValidatorHash(height uint64) (*types.Bytes32, error) {
+func (t *TMPop) getValidatorHash(height int64) (*types.Bytes32, error) {
 	key := getValidatorHashKey(height)
 	value, err := t.kvDB.GetValue(key)
 	if err != nil || value == nil {
@@ -83,7 +83,7 @@ func (t *TMPop) getValidatorHash(height uint64) (*types.Bytes32, error) {
 	return types.NewBytes32FromBytes(value), nil
 }
 
-func getCommitLinkHashesKey(height uint64) []byte {
+func getCommitLinkHashesKey(height int64) []byte {
 	key := fmt.Sprintf("tmpop:linkhashes:%d", height)
 	return []byte(key)
 }
@@ -118,7 +118,7 @@ func (t *TMPop) saveCommitLinkHashes(links []*cs.Link) error {
 
 // getCommitLinkHashes gets the link hashes included in a block at a specific height.
 // This is useful to ignore invalid links included in that block.
-func (t *TMPop) getCommitLinkHashes(height uint64) ([]types.Bytes32, error) {
+func (t *TMPop) getCommitLinkHashes(height int64) ([]types.Bytes32, error) {
 	key := getCommitLinkHashesKey(height)
 	value, err := t.kvDB.GetValue(key)
 	if err != nil || value == nil {

--- a/tmpop/error.go
+++ b/tmpop/error.go
@@ -1,0 +1,42 @@
+// Copyright 2017 Stratumn SAS. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tmpop
+
+import (
+	abci "github.com/tendermint/abci/types"
+)
+
+const (
+	// CodeTypeValidation is the ABCI error code for a validation error.
+	CodeTypeValidation uint32 = 400
+
+	// CodeTypeInternalError is the ABCI error code for an internal error.
+	CodeTypeInternalError uint32 = 500
+
+	// CodeTypeNotImplemented is the ABCI error code for a feature not yet implemented.
+	CodeTypeNotImplemented uint32 = 501
+)
+
+// ABCIError is a structured error used inside TMPoP.
+// The error codes are close to standard http status codes.
+type ABCIError struct {
+	Code uint32
+	Log  string
+}
+
+// IsOK returns true if no error occurred.
+func (e *ABCIError) IsOK() bool {
+	return e == nil || e.Code == abci.CodeTypeOK
+}

--- a/tmpop/error.go
+++ b/tmpop/error.go
@@ -15,6 +15,8 @@
 package tmpop
 
 import (
+	"fmt"
+
 	abci "github.com/tendermint/abci/types"
 )
 
@@ -39,4 +41,12 @@ type ABCIError struct {
 // IsOK returns true if no error occurred.
 func (e *ABCIError) IsOK() bool {
 	return e == nil || e.Code == abci.CodeTypeOK
+}
+
+func (e *ABCIError) Error() string {
+	if e.IsOK() {
+		return ""
+	}
+
+	return fmt.Sprintf("Code: %d. Log: %s", e.Code, e.Log)
 }

--- a/tmpop/state.go
+++ b/tmpop/state.go
@@ -24,7 +24,6 @@ import (
 	"github.com/stratumn/sdk/store"
 	"github.com/stratumn/sdk/types"
 	"github.com/stratumn/sdk/validator"
-	abci "github.com/tendermint/abci/types"
 )
 
 // State represents the app states, separating the committed state (for queries)
@@ -61,12 +60,12 @@ func NewState(a store.Adapter) (*State, error) {
 }
 
 // Check checks if creating this link is a valid operation
-func (s *State) Check(link *cs.Link) abci.Result {
+func (s *State) Check(link *cs.Link) *ABCIError {
 	return s.checkLinkAndAddToBatch(link, s.checkedLinks)
 }
 
 // Deliver adds a link to the list of links to be committed
-func (s *State) Deliver(link *cs.Link) abci.Result {
+func (s *State) Deliver(link *cs.Link) *ABCIError {
 	res := s.checkLinkAndAddToBatch(link, s.deliveredLinks)
 	if res.IsOK() {
 		s.deliveredLinksList = append(s.deliveredLinksList, link)
@@ -74,30 +73,33 @@ func (s *State) Deliver(link *cs.Link) abci.Result {
 	return res
 }
 
-func (s *State) checkLinkAndAddToBatch(link *cs.Link, batch store.Batch) abci.Result {
+func (s *State) checkLinkAndAddToBatch(link *cs.Link, batch store.Batch) *ABCIError {
 	err := link.Validate(batch.GetSegment)
 	if err != nil {
-		return abci.NewError(
+		return &ABCIError{
 			CodeTypeValidation,
 			fmt.Sprintf("Link validation failed %v: %v", link, err),
-		)
+		}
 	}
 
 	if s.validator != nil {
 		err = (*s.validator).Validate(batch, link)
 		if err != nil {
-			return abci.NewError(
+			return &ABCIError{
 				CodeTypeValidation,
 				fmt.Sprintf("Link validation rules failed %v: %v", link, err),
-			)
+			}
 		}
 	}
 
 	if _, err := batch.CreateLink(link); err != nil {
-		return abci.NewError(abci.CodeType_InternalError, err.Error())
+		return &ABCIError{
+			CodeTypeInternalError,
+			err.Error(),
+		}
 	}
 
-	return abci.OK
+	return nil
 }
 
 // Commit commits the delivered links,

--- a/tmpop/state.go
+++ b/tmpop/state.go
@@ -33,7 +33,7 @@ type State struct {
 	// The same validator is used for a whole commit
 	// When beginning a new block, the validator can
 	// be updated.
-	validator *validator.Validator
+	validator validator.Validator
 
 	adapter            store.Adapter
 	deliveredLinks     store.Batch
@@ -83,7 +83,7 @@ func (s *State) checkLinkAndAddToBatch(link *cs.Link, batch store.Batch) *ABCIEr
 	}
 
 	if s.validator != nil {
-		err = (*s.validator).Validate(batch, link)
+		err = s.validator.Validate(batch, link)
 		if err != nil {
 			return &ABCIError{
 				CodeTypeValidation,
@@ -131,7 +131,7 @@ func (s *State) Commit() (*types.Bytes32, []*cs.Link, error) {
 func (s *State) computeAppHash() (*types.Bytes32, error) {
 	var validatorHash *types.Bytes32
 	if s.validator != nil {
-		validatorHash = (*s.validator).Hash()
+		validatorHash = s.validator.Hash()
 	}
 
 	var merkleRoot *types.Bytes32

--- a/tmpop/tmClient.go
+++ b/tmpop/tmClient.go
@@ -45,7 +45,8 @@ func NewTendermintClient(tmClient client.Client) *TendermintClientWrapper {
 
 // Block queries for a block at a specific height
 func (c *TendermintClientWrapper) Block(height int) *Block {
-	previousBlock, err := c.tmClient.Block(&height)
+	requestHeight := int64(height)
+	previousBlock, err := c.tmClient.Block(&requestHeight)
 	if err != nil {
 		log.Warnf("Could not get previous block from Tendermint Core.\nSome evidence will be missing.\nError: %v", err)
 		return &Block{}
@@ -54,13 +55,14 @@ func (c *TendermintClientWrapper) Block(height int) *Block {
 	block := &Block{
 		Header: &abci.Header{
 			ChainId:        previousBlock.BlockMeta.Header.ChainID,
-			Height:         uint64(previousBlock.BlockMeta.Header.Height),
-			Time:           uint64(previousBlock.BlockMeta.Header.Time.Unix()),
+			Height:         int64(previousBlock.BlockMeta.Header.Height),
+			Time:           int64(previousBlock.BlockMeta.Header.Time.Unix()),
 			LastCommitHash: previousBlock.BlockMeta.Header.LastCommitHash,
 			DataHash:       previousBlock.BlockMeta.Header.DataHash,
 			AppHash:        previousBlock.BlockMeta.Header.AppHash,
 		},
 	}
+
 	for _, tx := range previousBlock.Block.Txs {
 		tmTx, err := unmarshallTx(tx)
 		if !err.IsOK() || tmTx.TxType != CreateLink {

--- a/tmpop/tmpop.go
+++ b/tmpop/tmpop.go
@@ -174,7 +174,7 @@ func (t *TMPop) BeginBlock(req abci.RequestBeginBlock) abci.ResponseBeginBlock {
 	// We should improve this and only reload when a config update was committed.
 	if t.config.ValidatorFilename != "" {
 		rootValidator := validator.NewRootValidator(t.config.ValidatorFilename, true)
-		t.state.validator = &rootValidator
+		t.state.validator = rootValidator
 	}
 
 	t.state.previousAppHash = types.NewBytes32FromBytes(t.currentHeader.AppHash)

--- a/tmpop/tmpop.go
+++ b/tmpop/tmpop.go
@@ -34,7 +34,7 @@ var tmpopLastBlockKey = []byte("tmpop:lastblock")
 // LastBlock saves the information of the last block committed for Core/App Handshake on crash/restart.
 type LastBlock struct {
 	AppHash    *types.Bytes32
-	Height     uint64
+	Height     int64
 	LastHeader *abci.Header
 }
 
@@ -80,11 +80,6 @@ const (
 
 	// Description of this Tendermint Application.
 	Description = "Agent Store in a Blockchain"
-)
-
-const (
-	// CodeTypeValidation is the ABCI error code for a validation error.
-	CodeTypeValidation abci.CodeType = 400
 )
 
 // New creates a new instance of a TMPop.
@@ -148,16 +143,19 @@ func (t *TMPop) Info(req abci.RequestInfo) abci.ResponseInfo {
 }
 
 // SetOption implements github.com/tendermint/abci/types.Application.SetOption.
-func (t *TMPop) SetOption(key string, value string) (log string) {
-	return "No options are supported yet"
+func (t *TMPop) SetOption(req abci.RequestSetOption) abci.ResponseSetOption {
+	return abci.ResponseSetOption{
+		Code: CodeTypeNotImplemented,
+		Log:  "No options are supported yet",
+	}
 }
 
 // BeginBlock implements github.com/tendermint/abci/types.Application.BeginBlock.
-func (t *TMPop) BeginBlock(req abci.RequestBeginBlock) {
+func (t *TMPop) BeginBlock(req abci.RequestBeginBlock) abci.ResponseBeginBlock {
 	t.currentHeader = req.GetHeader()
 	if t.currentHeader == nil {
 		log.Error("Cannot begin block without header")
-		return
+		return abci.ResponseBeginBlock{}
 	}
 
 	// If the AppHash of the previous block is present in this block's header,
@@ -180,32 +178,59 @@ func (t *TMPop) BeginBlock(req abci.RequestBeginBlock) {
 	}
 
 	t.state.previousAppHash = types.NewBytes32FromBytes(t.currentHeader.AppHash)
+
+	return abci.ResponseBeginBlock{}
 }
 
 // DeliverTx implements github.com/tendermint/abci/types.Application.DeliverTx.
-func (t *TMPop) DeliverTx(tx []byte) abci.Result {
-	return t.doTx(t.state.Deliver, tx)
+func (t *TMPop) DeliverTx(tx []byte) abci.ResponseDeliverTx {
+	err := t.doTx(t.state.Deliver, tx)
+	if !err.IsOK() {
+		return abci.ResponseDeliverTx{
+			Code: err.Code,
+			Log:  err.Log,
+		}
+	}
+
+	return abci.ResponseDeliverTx{}
 }
 
 // CheckTx implements github.com/tendermint/abci/types.Application.CheckTx.
-func (t *TMPop) CheckTx(tx []byte) abci.Result {
-	return t.doTx(t.state.Check, tx)
+func (t *TMPop) CheckTx(tx []byte) abci.ResponseCheckTx {
+	err := t.doTx(t.state.Check, tx)
+	if !err.IsOK() {
+		return abci.ResponseCheckTx{
+			Code: err.Code,
+			Log:  err.Log,
+		}
+	}
+
+	return abci.ResponseCheckTx{}
 }
 
 // Commit implements github.com/tendermint/abci/types.Application.Commit.
 // It actually commits the current state in the Store.
-func (t *TMPop) Commit() abci.Result {
+func (t *TMPop) Commit() abci.ResponseCommit {
 	appHash, links, err := t.state.Commit()
 	if err != nil {
-		return abci.NewError(abci.CodeType_InternalError, err.Error())
+		return abci.ResponseCommit{
+			Code: CodeTypeInternalError,
+			Log:  err.Error(),
+		}
 	}
 
 	if err := t.saveValidatorHash(); err != nil {
-		return abci.NewError(abci.CodeType_InternalError, err.Error())
+		return abci.ResponseCommit{
+			Code: CodeTypeInternalError,
+			Log:  err.Error(),
+		}
 	}
 
 	if err := t.saveCommitLinkHashes(links); err != nil {
-		return abci.NewError(abci.CodeType_InternalError, err.Error())
+		return abci.ResponseCommit{
+			Code: CodeTypeInternalError,
+			Log:  err.Error(),
+		}
 	}
 
 	t.eventsManager.AddSavedLinks(links)
@@ -215,13 +240,15 @@ func (t *TMPop) Commit() abci.Result {
 	t.lastBlock.LastHeader = t.currentHeader
 	saveLastBlock(t.kvDB, *t.lastBlock)
 
-	return abci.NewResultOK(appHash[:], "")
+	return abci.ResponseCommit{
+		Data: appHash[:],
+	}
 }
 
 // Query implements github.com/tendermint/abci/types.Application.Query.
 func (t *TMPop) Query(reqQuery abci.RequestQuery) (resQuery abci.ResponseQuery) {
 	if reqQuery.Height != 0 {
-		resQuery.Code = abci.CodeType_InternalError
+		resQuery.Code = CodeTypeInternalError
 		resQuery.Log = "tmpop only supports queries on latest commit"
 		return
 	}
@@ -290,12 +317,12 @@ func (t *TMPop) Query(reqQuery abci.RequestQuery) (resQuery abci.ResponseQuery) 
 		result = t.eventsManager.GetPendingEvents()
 
 	default:
-		resQuery.Code = abci.CodeType_UnknownRequest
+		resQuery.Code = CodeTypeNotImplemented
 		resQuery.Log = fmt.Sprintf("Unexpected Query path: %v", reqQuery.Path)
 	}
 
 	if err != nil {
-		resQuery.Code = abci.CodeType_InternalError
+		resQuery.Code = CodeTypeInternalError
 		resQuery.Log = err.Error()
 
 		return
@@ -303,7 +330,7 @@ func (t *TMPop) Query(reqQuery abci.RequestQuery) (resQuery abci.ResponseQuery) 
 	if result != nil {
 		resBytes, err := json.Marshal(result)
 		if err != nil {
-			resQuery.Code = abci.CodeType_InternalError
+			resQuery.Code = CodeTypeInternalError
 			resQuery.Log = err.Error()
 		}
 
@@ -313,21 +340,27 @@ func (t *TMPop) Query(reqQuery abci.RequestQuery) (resQuery abci.ResponseQuery) 
 	return
 }
 
-func (t *TMPop) doTx(createLink func(*cs.Link) abci.Result, txBytes []byte) abci.Result {
+func (t *TMPop) doTx(createLink func(*cs.Link) *ABCIError, txBytes []byte) *ABCIError {
 	if len(txBytes) == 0 {
-		return abci.ErrEncodingError.SetLog("Tx length cannot be zero")
+		return &ABCIError{
+			CodeTypeValidation,
+			"Tx length cannot be zero",
+		}
 	}
 
-	tx, res := unmarshallTx(txBytes)
-	if res.IsErr() {
-		return res
+	tx, err := unmarshallTx(txBytes)
+	if !err.IsOK() {
+		return err
 	}
 
 	switch tx.TxType {
 	case CreateLink:
 		return createLink(tx.Link)
 	default:
-		return abci.ErrUnknownRequest.SetLog(fmt.Sprintf("Unexpected Tx type byte %X", tx.TxType))
+		return &ABCIError{
+			CodeTypeNotImplemented,
+			fmt.Sprintf("Unexpected Tx type byte %X", tx.TxType),
+		}
 	}
 }
 

--- a/tmpop/tmpoptestcases/evidence.go
+++ b/tmpop/tmpoptestcases/evidence.go
@@ -44,7 +44,7 @@ func (f Factory) TestTendermintEvidence(t *testing.T) {
 	req = commitLink(t, h, invalidLink, req)
 	previousAppHash := req.Header.AppHash
 	tmClientMock.On("Block", 1).Return(&tmpop.Block{
-		Header: &abci.Header{Height: uint64(1)},
+		Header: &abci.Header{Height: int64(1)},
 	})
 
 	// Second block contains two valid links
@@ -61,7 +61,7 @@ func (f Factory) TestTendermintEvidence(t *testing.T) {
 	expectedTx2 := &tmpop.Tx{TxType: tmpop.CreateLink, Link: link2}
 	expectedBlock := &tmpop.Block{
 		Header: &abci.Header{
-			Height:  uint64(2),
+			Height:  int64(2),
 			AppHash: previousAppHash,
 		},
 		Txs: []*tmpop.Tx{expectedTx1, expectedTx2},

--- a/tmpop/tmpoptestcases/evidence.go
+++ b/tmpop/tmpoptestcases/evidence.go
@@ -82,7 +82,7 @@ func (f Factory) TestTendermintEvidence(t *testing.T) {
 
 		proof := evidence.Proof.(*evidences.TendermintProof)
 		assert.NotNil(t, proof, "h.Commit(): expected proof not to be nil")
-		assert.Equal(t, uint64(2), proof.BlockHeight, "Invalid block height in proof")
+		assert.Equal(t, int64(2), proof.BlockHeight, "Invalid block height in proof")
 
 		tree, _ := merkle.NewStaticTree([]types.Bytes32{*linkHash1, *linkHash2})
 		assert.EqualValues(t, tree.Root(), proof.Root, "Invalid proof merkle root")

--- a/tmpop/tmpoptestcases/query.go
+++ b/tmpop/tmpoptestcases/query.go
@@ -44,7 +44,7 @@ func (f Factory) TestQuery(t *testing.T) {
 
 	t.Run("Info() returns correct last seen height and app hash", func(t *testing.T) {
 		abciInfo := h.Info(abci.RequestInfo{})
-		assert.Equal(t, uint64(3), abciInfo.LastBlockHeight)
+		assert.Equal(t, int64(3), abciInfo.LastBlockHeight)
 	})
 
 	t.Run("GetInfo() correctly returns name", func(t *testing.T) {

--- a/tmpop/tmpoptestcases/query.go
+++ b/tmpop/tmpoptestcases/query.go
@@ -154,12 +154,12 @@ func (f Factory) TestQuery(t *testing.T) {
 		q := h.Query(abci.RequestQuery{
 			Path: "Unsupported",
 		})
-		assert.EqualValues(t, abci.CodeType_UnknownRequest, q.GetCode())
+		assert.EqualValues(t, tmpop.CodeTypeNotImplemented, q.GetCode())
 
 		q = h.Query(abci.RequestQuery{
 			Path:   tmpop.FindSegments,
 			Height: 12,
 		})
-		assert.EqualValues(t, abci.CodeType_InternalError, q.GetCode())
+		assert.EqualValues(t, tmpop.CodeTypeInternalError, q.GetCode())
 	})
 }

--- a/tmpop/tmpoptestcases/tmpoptestcases.go
+++ b/tmpop/tmpoptestcases/tmpoptestcases.go
@@ -82,7 +82,7 @@ func (f *Factory) newTMPop(t *testing.T, config *tmpop.Config) (*tmpop.TMPop, ab
 		t.Fatalf("tmpop.New(): err: %s", err)
 	}
 
-	return h, makeBeginBlock([]byte{}, uint64(1))
+	return h, makeBeginBlock([]byte{}, int64(1))
 }
 
 func makeQuery(h *tmpop.TMPop, name string, args interface{}, res interface{}) error {
@@ -116,7 +116,7 @@ func makeCreateLinkTx(t *testing.T, l *cs.Link) []byte {
 	return res
 }
 
-func makeBeginBlock(appHash []byte, height uint64) abci.RequestBeginBlock {
+func makeBeginBlock(appHash []byte, height int64) abci.RequestBeginBlock {
 	return abci.RequestBeginBlock{
 		Hash: []byte{},
 		Header: &abci.Header{

--- a/tmpop/tmpoptestcases/transaction.go
+++ b/tmpop/tmpoptestcases/transaction.go
@@ -85,7 +85,7 @@ func (f Factory) TestDeliverTx(t *testing.T) {
 	t.Run("Deliver link referencing a checked but not delivered link returns an error", func(t *testing.T) {
 		link, tx := makeCreateRandomLinkTx(t)
 		linkHash, _ := link.Hash()
-		res := h.CheckTx(tx)
+		h.CheckTx(tx)
 
 		linkWithRef := cstesting.RandomLinkWithProcess(link.GetProcess())
 		linkWithRef.Meta["refs"] = []interface{}{map[string]interface{}{
@@ -93,7 +93,7 @@ func (f Factory) TestDeliverTx(t *testing.T) {
 			"linkHash": linkHash,
 		}}
 		tx = makeCreateLinkTx(t, linkWithRef)
-		res = h.DeliverTx(tx)
+		res := h.DeliverTx(tx)
 
 		assert.EqualValues(t, tmpop.CodeTypeValidation, res.Code)
 	})

--- a/tmpop/transaction.go
+++ b/tmpop/transaction.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/stratumn/sdk/cs"
 	"github.com/stratumn/sdk/types"
-	abci "github.com/tendermint/abci/types"
 )
 
 // TxType represents the type of a Transaction
@@ -37,12 +36,12 @@ type Tx struct {
 	LinkHash *types.Bytes32 `json:"linkhash"`
 }
 
-func unmarshallTx(txBytes []byte) (*Tx, abci.Result) {
+func unmarshallTx(txBytes []byte) (*Tx, *ABCIError) {
 	tx := &Tx{}
 
 	if err := json.Unmarshal(txBytes, tx); err != nil {
-		return nil, abci.NewError(abci.CodeType_InternalError, err.Error())
+		return nil, &ABCIError{CodeTypeValidation, err.Error()}
 	}
 
-	return tx, abci.NewResultOK([]byte{}, "ok")
+	return tx, nil
 }

--- a/tmstore/tmstore.go
+++ b/tmstore/tmstore.go
@@ -17,6 +17,7 @@
 package tmstore
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"time"
@@ -32,7 +33,7 @@ import (
 	"github.com/tendermint/tendermint/rpc/client"
 	ctypes "github.com/tendermint/tendermint/rpc/core/types"
 	tmtypes "github.com/tendermint/tendermint/types"
-	"github.com/tendermint/tmlibs/events"
+	tmcommon "github.com/tendermint/tmlibs/common"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/stratumn/sdk/jsonhttp"
@@ -55,9 +56,10 @@ const (
 // TMStore is the type that implements github.com/stratumn/sdk/store.Adapter.
 type TMStore struct {
 	config          *Config
+	ctx             context.Context
+	tmEventChan     chan interface{}
 	storeEventChans []chan *store.Event
 	tmClient        client.Client
-	stoppingWS      bool
 	clientFactory   func(endpoint string) client.Client
 }
 
@@ -91,34 +93,44 @@ func New(config *Config) *TMStore {
 
 // NewFromClient creates a new instance of a TMStore with the given client.
 func NewFromClient(config *Config, clientFactory func(endpoint string) client.Client) *TMStore {
-	return &TMStore{config, nil, clientFactory(config.Endpoint), false, clientFactory}
+	return &TMStore{config, context.Background(), nil, nil, clientFactory(config.Endpoint), clientFactory}
 }
 
 // StartWebsocket starts the websocket client and wait for New Block events.
 func (t *TMStore) StartWebsocket() error {
-	t.stoppingWS = false
-	if _, err := t.tmClient.Start(); err != nil {
-		return err
+	if !t.tmClient.IsRunning() {
+		if err := t.tmClient.Start(); err != nil && err != tmcommon.ErrAlreadyStarted {
+			return err
+		}
 	}
 
 	// TMPoP notifies us of store events that we forward to clients
-	t.tmClient.AddListenerForEvent("TMStore", tmtypes.EventStringNewBlock(), func(_ events.EventData) {
-		go t.notifyStoreChans()
-	})
+	t.tmEventChan = make(chan interface{}, 10)
+	go func() {
+		for {
+			_, ok := <-t.tmEventChan
+			if !ok {
+				break
+			}
+
+			go t.notifyStoreChans()
+		}
+	}()
+
+	newBlocksQuery := fmt.Sprintf("%s='%s'", tmtypes.EventTypeKey, tmtypes.EventNewBlock)
+	if err := t.tmClient.Subscribe(t.ctx, newBlocksQuery, t.tmEventChan); err != nil {
+		return err
+	}
 
 	log.Info("Connected to TMPoP")
 	return nil
 }
 
-// RetryStartWebsocket starts the websocket client and wait for New Block events, it retries on errors.
+// RetryStartWebsocket starts the websocket client and retries on errors.
 func (t *TMStore) RetryStartWebsocket(interval time.Duration) error {
 	return utils.Retry(func(attempt int) (retry bool, err error) {
 		err = t.StartWebsocket()
 		if err != nil {
-			// the tendermint RPC HTTPClient does not handle well connection errors
-			// we have to recreate the client in case of errors
-			// (Check if it is still needed on Tendermint updates)
-			t.tmClient = t.clientFactory(t.config.Endpoint)
 			log.Infof("%v, retrying...", err)
 			time.Sleep(interval)
 		}
@@ -127,9 +139,21 @@ func (t *TMStore) RetryStartWebsocket(interval time.Duration) error {
 }
 
 // StopWebsocket stops the websocket client.
-func (t *TMStore) StopWebsocket() {
-	t.stoppingWS = true
-	t.tmClient.Stop()
+func (t *TMStore) StopWebsocket() error {
+	// Note: no need to close t.tmEventChan, unsubscribing handles it
+	if err := t.tmClient.UnsubscribeAll(t.ctx); err != nil {
+		log.Warnf("Error unsubscribing to Tendermint events: %s", err.Error())
+		return err
+	}
+
+	if t.tmClient.IsRunning() {
+		if err := t.tmClient.Stop(); err != nil && err != tmcommon.ErrAlreadyStopped {
+			log.Warnf("Error stopping Tendermint client: %s", err.Error())
+			return err
+		}
+	}
+
+	return nil
 }
 
 func (t *TMStore) notifyStoreChans() {
@@ -321,19 +345,19 @@ func (t *TMStore) broadcastTx(tx *tmpop.Tx) (*ctypes.ResultBroadcastTxCommit, er
 	return result, nil
 }
 
-func (t *TMStore) sendQuery(name string, args interface{}) (res *abci.ResultQuery, err error) {
+func (t *TMStore) sendQuery(name string, args interface{}) (res *abci.ResponseQuery, err error) {
 	query, err := tmpop.BuildQueryBinary(args)
 	if err != nil {
 		return
 	}
 
-	result, err := t.tmClient.ABCIQuery(name, query)
+	response, err := t.tmClient.ABCIQuery(name, query)
 	if err != nil {
 		return
 	}
-	if !result.ResultQuery.Code.IsOK() {
-		return res, fmt.Errorf("NOK Response from TMPop: %v", result.ResultQuery)
+	if !response.Response.IsOK() {
+		return res, fmt.Errorf("NOK Response from TMPop: %v", response.Response)
 	}
 
-	return result.ResultQuery, nil
+	return &response.Response, nil
 }

--- a/tmstore/tmstore.go
+++ b/tmstore/tmstore.go
@@ -60,7 +60,6 @@ type TMStore struct {
 	tmEventChan     chan interface{}
 	storeEventChans []chan *store.Event
 	tmClient        client.Client
-	clientFactory   func(endpoint string) client.Client
 }
 
 // Config contains configuration options for the store.
@@ -70,9 +69,6 @@ type Config struct {
 
 	// A git commit hash that will be set in the store's information.
 	Commit string
-
-	// Endoint used to communicate with Tendermint core
-	Endpoint string
 }
 
 // Info is the info returned by GetInfo.
@@ -85,15 +81,12 @@ type Info struct {
 }
 
 // New creates a new instance of a TMStore.
-func New(config *Config) *TMStore {
-	return NewFromClient(config, func(endpoint string) client.Client {
-		return client.NewHTTP(endpoint, "/websocket")
-	})
-}
-
-// NewFromClient creates a new instance of a TMStore with the given client.
-func NewFromClient(config *Config, clientFactory func(endpoint string) client.Client) *TMStore {
-	return &TMStore{config, context.Background(), nil, nil, clientFactory(config.Endpoint), clientFactory}
+func New(config *Config, tmClient client.Client) *TMStore {
+	return &TMStore{
+		config:   config,
+		ctx:      context.Background(),
+		tmClient: tmClient,
+	}
 }
 
 // StartWebsocket starts the websocket client and wait for New Block events.

--- a/tmstore/util_test.go
+++ b/tmstore/util_test.go
@@ -44,9 +44,13 @@ func StartNode() *node.Node {
 		panic(err)
 	}
 
-	testNode = rpctest.StartTendermint(testTmpop)
+	testNode = rpctest.NewTendermint(testTmpop)
 	testClient := tmpop.NewTendermintClient(client.NewLocal(testNode))
 	testTmpop.ConnectTendermint(testClient)
+
+	if err = testNode.Start(); err != nil {
+		panic(err)
+	}
 
 	return testNode
 }

--- a/tmstore/util_test.go
+++ b/tmstore/util_test.go
@@ -24,9 +24,7 @@ var (
 
 // NewTestClient returns a rpc client pointing to the test node
 func NewTestClient() *TMStore {
-	return NewFromClient(&Config{}, func(endpoint string) client.Client {
-		return client.NewLocal(testNode)
-	})
+	return New(&Config{}, client.NewLocal(testNode))
 }
 
 func ResetNode() {


### PR DESCRIPTION
Update to Tendermint 0.13.0 (0.14.0 is advertised as release but in fact it requires a commit from tmlibs' develop branch, so it's not really ready for release yet).
There was a big types change where Tendermint removed a lot of their types and forces us to have different return types per ABCI operation. I think it's overall a good change, our internal types in TMPoP were too tightly coupled with Tendermint's types, so I introduced an ABCIError type inside TMPoP.
Socket management / events changed a lot and isn't well documented, I had to dig through Tendermint's code to get it to work.
I want to do an end-to-end test with multiple nodes before committing this change, I'll be working on that today and will report the results on this PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stratumn/sdk/292)
<!-- Reviewable:end -->
