### PR TITLE
agent-client-go: test cases and mock agent

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -151,6 +151,18 @@
   revision = "53e6ce116135b80d037921a7fdd5138cf32d7a8a"
 
 [[projects]]
+  name = "github.com/gorilla/context"
+  packages = ["."]
+  revision = "1ea25387ff6f684839d82767c1733ff4d4d15d0a"
+  version = "v1.1"
+
+[[projects]]
+  name = "github.com/gorilla/mux"
+  packages = ["."]
+  revision = "7f08801859139f86dfafd1c296e2cba9a80d292e"
+  version = "v1.6.0"
+
+[[projects]]
   name = "github.com/gorilla/websocket"
   packages = ["."]
   revision = "ea4d1f681babbce9545c9c5f3d5194a789c89f5b"
@@ -465,6 +477,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "d49a1f6093a9c510efcdc344ba0b1d99005dfddc670ad1bf1ca42773befe7d1f"
+  inputs-digest = "7c53caf303ae5ef35c261479fa9dba180ced1b9efb8ea6112f8fb046f5d16113"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -11,6 +11,10 @@
   version = "1.2.0"
 
 [[constraint]]
+  name = "github.com/gorilla/mux"
+  version = "1.6.0"
+
+[[constraint]]
   name = "github.com/julienschmidt/httprouter"
   version = "1.1.0"
 
@@ -70,3 +74,6 @@
   name = "github.com/golang/mock"
   branch="master"
   
+[[constraint]]
+  name = "github.com/google/go-querystring"
+  branch="master"

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -10,7 +10,7 @@ import (
 
 // Info is the data structure returned by Agent.GetInfo()
 type Info struct {
-	Processes   Processes        `json:"processes"`
+	Processes   ProcessesMap     `json:"processes"`
 	Stores      []StoreInfo      `json:"stores"`
 	Fossilizers []FossilizerInfo `json:"fossilizers"`
 	Plugins     Plugins          `json:"plugins"`
@@ -36,7 +36,7 @@ type Agent interface {
 	AddProcess(process string, actions Actions, storeClient interface{}, fossilizerClients []interface{}, opts *ProcessOptions) (Process, error)
 	FindSegments(filter store.SegmentFilter) (cs.SegmentSlice, error)
 	GetInfo() (*Info, error)
-	GetMapIds(filter store.MapFilter) (cs.SegmentSlice, error)
+	GetMapIds(filter store.MapFilter) ([]string, error)
 	GetProcesses() (Processes, error)
 	GetProcess(process string) (*Process, error)
 	GetSegment(process string, linkHash types.Bytes32)

--- a/agent/agenttestcases/agenttestcases.go
+++ b/agent/agenttestcases/agenttestcases.go
@@ -1,0 +1,70 @@
+package agenttestcases
+
+import (
+	"net/http"
+	"testing"
+
+	log "github.com/sirupsen/logrus"
+
+	"github.com/stratumn/sdk/agent/client"
+)
+
+var agentURL = "http://localhost:3000"
+
+// Factory wraps functions to mock an HTTP server for an agent and run
+// the tests for the agent and its client
+type Factory struct {
+	NewMock   func(t *testing.T, agentURL string) *http.Server
+	NewClient func(agentURL string) (client.AgentClient, error)
+
+	Client client.AgentClient
+}
+
+// RunAgentClientTests runs the test suite for an agent client
+func (f Factory) RunAgentClientTests(t *testing.T) {
+	if f.NewMock != nil {
+		srv := f.NewMock(t, agentURL)
+		defer func() {
+			if err := srv.Shutdown(nil); err != nil {
+				log.WithField("error", err).Fatal("Failed to shutdown HTTP server")
+			}
+		}()
+
+	}
+	f.Client, _ = f.NewClient(agentURL)
+
+	t.Run("TestCreateMap", f.TestCreateMap)
+	t.Run("TestCreateMapWithRefs", f.TestCreateMapWithRefs)
+	t.Run("TestCreateMapWithBadRefs", f.TestCreateMapWithBadRefs)
+	t.Run("TestCreateMapHandlesWrongInitArgs", f.TestCreateMapHandlesWrongInitArgs)
+
+	t.Run("TestCreateLink", f.TestCreateLink)
+	t.Run("TestCreateLinkWithRefs", f.TestCreateLinkWithRefs)
+	t.Run("TestCreateLinkWithBadRefs", f.TestCreateLinkWithBadRefs)
+	t.Run("TestCreateLinkHandlesWrongAction", f.TestCreateLinkHandlesWrongAction)
+	t.Run("TestCreateLinkHandlesWrongActionArgs", f.TestCreateLinkHandlesWrongActionArgs)
+	t.Run("TestCreateLinkHandlesWrongLinkHash", f.TestCreateLinkHandlesWrongLinkHash)
+	t.Run("TestCreateLinkHandlesWrongProcess", f.TestCreateLinkHandlesWrongProcess)
+
+	t.Run("TestFindSegments", f.TestFindSegments)
+	t.Run("TestFindSegmentsLimit", f.TestFindSegmentsLimit)
+	t.Run("TestFindSegmentsLinkHashes", f.TestFindSegmentsLinkHashes)
+	t.Run("TestFindSegmentsMapIDs", f.TestFindSegmentsMapIDs)
+	t.Run("TestFindSegmentsTags", f.TestFindSegmentsTags)
+	t.Run("TestFindSegmentsNoMatch", f.TestFindSegmentsNoMatch)
+
+	t.Run("TestGetInfo", f.TestGetInfo)
+
+	t.Run("TestGetMapIds", f.TestGetMapIds)
+	t.Run("TestGetMapIdsLimit", f.TestGetMapIdsLimit)
+	t.Run("TestGetMapIdsNoLimit", f.TestGetMapIdsNoLimit)
+	t.Run("TestGetMapIdsNoMatch", f.TestGetMapIdsNoMatch)
+
+	t.Run("TestGetProcess", f.TestGetProcess)
+	t.Run("TestGetProcessNotFound", f.TestGetProcessNotFound)
+
+	t.Run("TestGetProcesses", f.TestGetProcesses)
+
+	t.Run("TestGetSegment", f.TestGetSegment)
+	t.Run("TestGetSegmentNotFound", f.TestGetSegmentNotFound)
+}

--- a/agent/agenttestcases/agenttestcases.go
+++ b/agent/agenttestcases/agenttestcases.go
@@ -11,8 +11,9 @@ import (
 
 var agentURL = "http://localhost:3000"
 
-// Factory wraps functions to mock an HTTP server for an agent and run
-// the  for the agent and its client
+// Factory wraps functions to create a client and a mock agent.
+// After its creation, the client is stored in the factory to avoid
+// re-creating it in every test.
 type Factory struct {
 	NewMock   func(t *testing.T, agentURL string) *http.Server
 	NewClient func(agentURL string) (client.AgentClient, error)

--- a/agent/agenttestcases/agenttestcases.go
+++ b/agent/agenttestcases/agenttestcases.go
@@ -12,7 +12,7 @@ import (
 var agentURL = "http://localhost:3000"
 
 // Factory wraps functions to mock an HTTP server for an agent and run
-// the tests for the agent and its client
+// the  for the agent and its client
 type Factory struct {
 	NewMock   func(t *testing.T, agentURL string) *http.Server
 	NewClient func(agentURL string) (client.AgentClient, error)
@@ -33,38 +33,70 @@ func (f Factory) RunAgentClientTests(t *testing.T) {
 	}
 	f.Client, _ = f.NewClient(agentURL)
 
-	t.Run("TestCreateMap", f.TestCreateMap)
+	t.Run("Test creating map", f.TestCreateMap)
+	t.Run("Test creating link", f.TestCreateLink)
+	t.Run("Test find segments", f.TestFindSegments)
+	t.Run("Test getting infos", f.TestGetInfo)
+	t.Run("Test getting a process", f.TestGetProcess)
+	t.Run("Test getting all the processes", f.TestGetProcesses)
+	t.Run("Test getting a segment", f.TestGetSegment)
+}
+
+// TestCreateMap tests what happens when creating a map with various inputs
+func (f Factory) TestCreateMap(t *testing.T) {
+	t.Run("TestCreateMap", f.TestCreateMapOK)
 	t.Run("TestCreateMapWithRefs", f.TestCreateMapWithRefs)
 	t.Run("TestCreateMapWithBadRefs", f.TestCreateMapWithBadRefs)
 	t.Run("TestCreateMapHandlesWrongInitArgs", f.TestCreateMapHandlesWrongInitArgs)
+}
 
-	t.Run("TestCreateLink", f.TestCreateLink)
+// TestCreateLink tests what happens when creating a link with various inputs
+func (f Factory) TestCreateLink(t *testing.T) {
+	t.Run("TestCreateLink", f.TestCreateLinkOK)
 	t.Run("TestCreateLinkWithRefs", f.TestCreateLinkWithRefs)
 	t.Run("TestCreateLinkWithBadRefs", f.TestCreateLinkWithBadRefs)
 	t.Run("TestCreateLinkHandlesWrongAction", f.TestCreateLinkHandlesWrongAction)
 	t.Run("TestCreateLinkHandlesWrongActionArgs", f.TestCreateLinkHandlesWrongActionArgs)
 	t.Run("TestCreateLinkHandlesWrongLinkHash", f.TestCreateLinkHandlesWrongLinkHash)
 	t.Run("TestCreateLinkHandlesWrongProcess", f.TestCreateLinkHandlesWrongProcess)
+}
 
-	t.Run("TestFindSegments", f.TestFindSegments)
+// TestFindSegments tests what happens when finding segments with various filters
+func (f Factory) TestFindSegments(t *testing.T) {
+	t.Run("TestFindSegments", f.TestFindSegmentsOK)
 	t.Run("TestFindSegmentsLimit", f.TestFindSegmentsLimit)
 	t.Run("TestFindSegmentsLinkHashes", f.TestFindSegmentsLinkHashes)
 	t.Run("TestFindSegmentsMapIDs", f.TestFindSegmentsMapIDs)
 	t.Run("TestFindSegmentsTags", f.TestFindSegmentsTags)
 	t.Run("TestFindSegmentsNoMatch", f.TestFindSegmentsNoMatch)
+}
 
-	t.Run("TestGetInfo", f.TestGetInfo)
+// TestGetInfo tests what happens when getting an agent's infos
+func (f Factory) TestGetInfo(t *testing.T) {
+	t.Run("TestGetInfo", f.TestGetInfoOK)
+}
 
-	t.Run("TestGetMapIds", f.TestGetMapIds)
+// TestGetMapIds tests what happens when finding map ids with varisou filters
+func (f Factory) TestGetMapIds(t *testing.T) {
+	t.Run("TestGetMapIds", f.TestGetMapIdsOK)
 	t.Run("TestGetMapIdsLimit", f.TestGetMapIdsLimit)
 	t.Run("TestGetMapIdsNoLimit", f.TestGetMapIdsNoLimit)
 	t.Run("TestGetMapIdsNoMatch", f.TestGetMapIdsNoMatch)
+}
 
-	t.Run("TestGetProcess", f.TestGetProcess)
+// TestGetProcess tests what happens when getting informations about a process
+func (f Factory) TestGetProcess(t *testing.T) {
+	t.Run("TestGetProcess", f.TestGetProcessOK)
 	t.Run("TestGetProcessNotFound", f.TestGetProcessNotFound)
+}
 
-	t.Run("TestGetProcesses", f.TestGetProcesses)
+// TestGetProcesses tests what happens whengetting all the processes from an agent
+func (f Factory) TestGetProcesses(t *testing.T) {
+	t.Run("TestGetProcesses", f.TestGetProcessesOK)
+}
 
-	t.Run("TestGetSegment", f.TestGetSegment)
+// TestGetSegment tests what happens when getting a segment
+func (f Factory) TestGetSegment(t *testing.T) {
+	t.Run("TestGetSegment", f.TestGetSegmentOK)
 	t.Run("TestGetSegmentNotFound", f.TestGetSegmentNotFound)
 }

--- a/agent/agenttestcases/createlink.go
+++ b/agent/agenttestcases/createlink.go
@@ -4,8 +4,8 @@ import (
 	"testing"
 )
 
-// TestCreateLink tests the client's ability to handle a CreateLink request
-func (f Factory) TestCreateLink(t *testing.T) {
+// TestCreateLinkOK tests the client's ability to handle a CreateLink request
+func (f Factory) TestCreateLinkOK(t *testing.T) {
 }
 
 // TestCreateLinkWithRefs tests the client's ability to handle a CreateLink request

--- a/agent/agenttestcases/createlink.go
+++ b/agent/agenttestcases/createlink.go
@@ -1,0 +1,39 @@
+package agenttestcases
+
+import (
+	"testing"
+)
+
+// TestCreateLink tests the client's ability to handle a CreateLink request
+func (f Factory) TestCreateLink(t *testing.T) {
+}
+
+// TestCreateLinkWithRefs tests the client's ability to handle a CreateLink request
+// when a reference is passed
+func (f Factory) TestCreateLinkWithRefs(t *testing.T) {
+}
+
+// TestCreateLinkWithBadRefs tests the client's ability to handle a CreateLink request
+// when a reference is passed
+func (f Factory) TestCreateLinkWithBadRefs(t *testing.T) {
+}
+
+// TestCreateLinkHandlesWrongProcess tests the client's ability to handle a CreateLink request
+// when the provided process does not exist
+func (f Factory) TestCreateLinkHandlesWrongProcess(t *testing.T) {
+}
+
+// TestCreateLinkHandlesWrongLinkHash tests the client's ability to handle a CreateLink request
+// when the provided parent's linkHash does not exist
+func (f Factory) TestCreateLinkHandlesWrongLinkHash(t *testing.T) {
+}
+
+// TestCreateLinkHandlesWrongAction tests the client's ability to handle a CreateLink request
+// when the provided action does not exist
+func (f Factory) TestCreateLinkHandlesWrongAction(t *testing.T) {
+}
+
+// TestCreateLinkHandlesWrongActionArgs tests the client's ability to handle a CreateLink request
+// when the provided action's arguments do not match the actual ones
+func (f Factory) TestCreateLinkHandlesWrongActionArgs(t *testing.T) {
+}

--- a/agent/agenttestcases/createmap.go
+++ b/agent/agenttestcases/createmap.go
@@ -1,0 +1,27 @@
+package agenttestcases
+
+import (
+	"testing"
+)
+
+// TestCreateMap tests the client's ability to handle a CreateMap request
+func (f Factory) TestCreateMap(t *testing.T) {
+}
+
+// TestCreateMapWithRefs tests the client's ability to handle a CreateMap request
+// when one or multiple references are passed
+func (f Factory) TestCreateMapWithRefs(t *testing.T) {
+
+}
+
+// TestCreateMapWithBadRefs tests the client's ability to handle a CreateMap request
+// when the provided reference is ill formatted
+func (f Factory) TestCreateMapWithBadRefs(t *testing.T) {
+
+}
+
+// TestCreateMapHandlesWrongInitArgs tests the client's ability to handle a CreateMap request
+// when the provided arguments do not match those of the 'init' function
+func (f Factory) TestCreateMapHandlesWrongInitArgs(t *testing.T) {
+
+}

--- a/agent/agenttestcases/createmap.go
+++ b/agent/agenttestcases/createmap.go
@@ -4,8 +4,8 @@ import (
 	"testing"
 )
 
-// TestCreateMap tests the client's ability to handle a CreateMap request
-func (f Factory) TestCreateMap(t *testing.T) {
+// TestCreateMapOK tests the client's ability to handle a CreateMap request
+func (f Factory) TestCreateMapOK(t *testing.T) {
 }
 
 // TestCreateMapWithRefs tests the client's ability to handle a CreateMap request

--- a/agent/agenttestcases/findsegments.go
+++ b/agent/agenttestcases/findsegments.go
@@ -15,7 +15,7 @@ func (f Factory) TestFindSegmentsTags(t *testing.T) {
 }
 
 // TestFindSegmentsLinkHashes tests the client's ability to handle a FindSegment request
-// when linkHashes are set in the filter
+// when LinkHashes are set in the filter
 func (f Factory) TestFindSegmentsLinkHashes(t *testing.T) {
 
 }
@@ -33,7 +33,7 @@ func (f Factory) TestFindSegmentsLimit(t *testing.T) {
 }
 
 // TestFindSegmentsNoLimit tests the client's ability to handle a FindSegment request
-// when a limit is set in the filter
+// when the limit is set to -1 in the filter to retrieve all segments
 func (f Factory) TestFindSegmentsNoLimit(t *testing.T) {
 
 }

--- a/agent/agenttestcases/findsegments.go
+++ b/agent/agenttestcases/findsegments.go
@@ -4,9 +4,8 @@ import (
 	"testing"
 )
 
-// TestFindSegments tests the client's ability to handle a FindSegment request
-func (f Factory) TestFindSegments(t *testing.T) {
-
+// TestFindSegmentsOK tests the client's ability to handle a FindSegment request
+func (f Factory) TestFindSegmentsOK(t *testing.T) {
 }
 
 // TestFindSegmentsTags tests the client's ability to handle a FindSegment request

--- a/agent/agenttestcases/findsegments.go
+++ b/agent/agenttestcases/findsegments.go
@@ -1,0 +1,45 @@
+package agenttestcases
+
+import (
+	"testing"
+)
+
+// TestFindSegments tests the client's ability to handle a FindSegment request
+func (f Factory) TestFindSegments(t *testing.T) {
+
+}
+
+// TestFindSegmentsTags tests the client's ability to handle a FindSegment request
+// when tags are set in the filter
+func (f Factory) TestFindSegmentsTags(t *testing.T) {
+}
+
+// TestFindSegmentsLinkHashes tests the client's ability to handle a FindSegment request
+// when linkHashes are set in the filter
+func (f Factory) TestFindSegmentsLinkHashes(t *testing.T) {
+
+}
+
+// TestFindSegmentsMapIDs tests the client's ability to handle a FindSegment request
+// when a map ID is set in the filter
+func (f Factory) TestFindSegmentsMapIDs(t *testing.T) {
+
+}
+
+// TestFindSegmentsLimit tests the client's ability to handle a FindSegment request
+// when a limit is set in the filter
+func (f Factory) TestFindSegmentsLimit(t *testing.T) {
+
+}
+
+// TestFindSegmentsNoLimit tests the client's ability to handle a FindSegment request
+// when a limit is set in the filter
+func (f Factory) TestFindSegmentsNoLimit(t *testing.T) {
+
+}
+
+// TestFindSegmentsNoMatch tests the client's ability to handle a FindSegment request
+// when no segment is found
+func (f Factory) TestFindSegmentsNoMatch(t *testing.T) {
+
+}

--- a/agent/agenttestcases/getinfo.go
+++ b/agent/agenttestcases/getinfo.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 )
 
-// TestGetInfo tests the client's ability to handle a GetInfo request
-func (f Factory) TestGetInfo(t *testing.T) {
-
+// TestGetInfoOK tests the client's ability to handle a GetInfo request
+func (f Factory) TestGetInfoOK(t *testing.T) {
 }

--- a/agent/agenttestcases/getinfo.go
+++ b/agent/agenttestcases/getinfo.go
@@ -1,0 +1,10 @@
+package agenttestcases
+
+import (
+	"testing"
+)
+
+// TestGetInfo tests the client's ability to handle a GetInfo request
+func (f Factory) TestGetInfo(t *testing.T) {
+
+}

--- a/agent/agenttestcases/getmapids.go
+++ b/agent/agenttestcases/getmapids.go
@@ -1,0 +1,28 @@
+package agenttestcases
+
+import (
+	"testing"
+)
+
+// TestGetMapIds tests the client's ability to handle a GetMapIds request
+func (f Factory) TestGetMapIds(t *testing.T) {
+
+}
+
+// TestGetMapIdsLimit tests the client's ability to handle a GetMapIds request
+// when no mapID is found
+func (f Factory) TestGetMapIdsLimit(t *testing.T) {
+
+}
+
+// TestGetMapIdsNoLimit tests the client's ability to handle a GetMapIds request
+// when no mapID is found
+func (f Factory) TestGetMapIdsNoLimit(t *testing.T) {
+
+}
+
+// TestGetMapIdsNoMatch tests the client's ability to handle a GetMapIds request
+// when no mapID is found
+func (f Factory) TestGetMapIdsNoMatch(t *testing.T) {
+
+}

--- a/agent/agenttestcases/getmapids.go
+++ b/agent/agenttestcases/getmapids.go
@@ -10,13 +10,13 @@ func (f Factory) TestGetMapIds(t *testing.T) {
 }
 
 // TestGetMapIdsLimit tests the client's ability to handle a GetMapIds request
-// when no mapID is found
+// when a limit is set in the filter
 func (f Factory) TestGetMapIdsLimit(t *testing.T) {
 
 }
 
 // TestGetMapIdsNoLimit tests the client's ability to handle a GetMapIds request
-// when no mapID is found
+// when the limit is set to -1 to retrieve all map IDs
 func (f Factory) TestGetMapIdsNoLimit(t *testing.T) {
 
 }

--- a/agent/agenttestcases/getmapids.go
+++ b/agent/agenttestcases/getmapids.go
@@ -4,9 +4,8 @@ import (
 	"testing"
 )
 
-// TestGetMapIds tests the client's ability to handle a GetMapIds request
-func (f Factory) TestGetMapIds(t *testing.T) {
-
+// TestGetMapIdsOK tests the client's ability to handle a GetMapIds request
+func (f Factory) TestGetMapIdsOK(t *testing.T) {
 }
 
 // TestGetMapIdsLimit tests the client's ability to handle a GetMapIds request

--- a/agent/agenttestcases/getprocess.go
+++ b/agent/agenttestcases/getprocess.go
@@ -4,9 +4,8 @@ import (
 	"testing"
 )
 
-// TestGetProcess tests the client's ability to handle a GetProcess request
-func (f Factory) TestGetProcess(t *testing.T) {
-
+// TestGetProcessOK tests the client's ability to handle a GetProcess request
+func (f Factory) TestGetProcessOK(t *testing.T) {
 }
 
 // TestGetProcessNotFound tests the client's ability to handle a FindSegment request

--- a/agent/agenttestcases/getprocess.go
+++ b/agent/agenttestcases/getprocess.go
@@ -1,0 +1,16 @@
+package agenttestcases
+
+import (
+	"testing"
+)
+
+// TestGetProcess tests the client's ability to handle a GetProcess request
+func (f Factory) TestGetProcess(t *testing.T) {
+
+}
+
+// TestGetProcessNotFound tests the client's ability to handle a FindSegment request
+// when no process is found
+func (f Factory) TestGetProcessNotFound(t *testing.T) {
+
+}

--- a/agent/agenttestcases/getprocesses.go
+++ b/agent/agenttestcases/getprocesses.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 )
 
-// TestGetProcesses tests the client's ability to handle a GetProcesses request
-func (f Factory) TestGetProcesses(t *testing.T) {
-
+// TestGetProcessesOK tests the client's ability to handle a GetProcesses request
+func (f Factory) TestGetProcessesOK(t *testing.T) {
 }

--- a/agent/agenttestcases/getprocesses.go
+++ b/agent/agenttestcases/getprocesses.go
@@ -1,0 +1,10 @@
+package agenttestcases
+
+import (
+	"testing"
+)
+
+// TestGetProcesses tests the client's ability to handle a GetProcesses request
+func (f Factory) TestGetProcesses(t *testing.T) {
+
+}

--- a/agent/agenttestcases/getsegment.go
+++ b/agent/agenttestcases/getsegment.go
@@ -4,9 +4,8 @@ import (
 	"testing"
 )
 
-// TestGetSegment tests the client's ability to handle a GetSegment request
-func (f Factory) TestGetSegment(t *testing.T) {
-
+// TestGetSegmentOK tests the client's ability to handle a GetSegment request
+func (f Factory) TestGetSegmentOK(t *testing.T) {
 }
 
 // TestGetSegmentNotFound tests the client's ability to handle a GetSegment request

--- a/agent/agenttestcases/getsegment.go
+++ b/agent/agenttestcases/getsegment.go
@@ -1,0 +1,16 @@
+package agenttestcases
+
+import (
+	"testing"
+)
+
+// TestGetSegment tests the client's ability to handle a GetSegment request
+func (f Factory) TestGetSegment(t *testing.T) {
+
+}
+
+// TestGetSegmentNotFound tests the client's ability to handle a GetSegment request
+// when it does not exist
+func (f Factory) TestGetSegmentNotFound(t *testing.T) {
+
+}

--- a/agent/agenttestcases/getsegment.go
+++ b/agent/agenttestcases/getsegment.go
@@ -10,7 +10,7 @@ func (f Factory) TestGetSegment(t *testing.T) {
 }
 
 // TestGetSegmentNotFound tests the client's ability to handle a GetSegment request
-// when it does not exist
+// when the queried linkHash does not exist
 func (f Factory) TestGetSegmentNotFound(t *testing.T) {
 
 }

--- a/agent/client/client.go
+++ b/agent/client/client.go
@@ -1,7 +1,7 @@
 package client
 
 import (
-	"bytes"
+	"errors"
 	"net/http"
 	"net/url"
 
@@ -11,11 +11,11 @@ import (
 	"github.com/stratumn/sdk/types"
 )
 
-// DefaultURL is the default url for an agent
-const DefaultURL = "http://agent"
-
-// DefaultPort is the default port for an agent
-const DefaultPort = "3000"
+// ErrorData is the format used by an agent to format errors
+type ErrorData struct {
+	Status  int    `json:"status"`
+	Message string `json:"error"`
+}
 
 //SegmentRef defines a format for a valid reference
 type SegmentRef struct {
@@ -29,45 +29,47 @@ type SegmentRef struct {
 // It can be used to access an agent's http endpoints
 type AgentClient interface {
 	CreateMap(process string, refs []SegmentRef, args ...string) (*cs.Segment, error)
-	CreateLink(process string, linkHash types.Bytes32, action string, refs []SegmentRef, args ...string) (*cs.Segment, error)
+	CreateLink(process string, linkHash *types.Bytes32, action string, refs []SegmentRef, args ...string) (*cs.Segment, error)
 	FindSegments(filter *store.SegmentFilter) (cs.SegmentSlice, error)
 	GetInfo() (*agent.Info, error)
-	GetMapIds(filter *store.MapFilter) (cs.SegmentSlice, error)
+	GetMapIds(filter *store.MapFilter) ([]string, error)
+	GetProcess(name string) (*agent.Process, error)
 	GetProcesses() (agent.Processes, error)
-	GetSegment(process string, linkHash types.Bytes32) (*cs.Segment, error)
+	GetSegment(process string, linkHash *types.Bytes32) (*cs.Segment, error)
 	URL() string
 }
 
 // agentClient wraps an http.Client used to send request to the agent's server
 type agentClient struct {
-	c        *http.Client
-	agentURL *url.URL
+	c         *http.Client
+	agentURL  *url.URL
+	agentInfo agent.Info
 }
 
 // NewAgentClient returns an initialized AgentClient
 // If the provided url is empty, it will use a default one
 func NewAgentClient(agentURL string) (AgentClient, error) {
 	if len(agentURL) == 0 {
-		agentURL = DefaultURL + ":" + DefaultPort
+		return nil, errors.New("An URL must be provided to initialize a client")
 	}
 	url, err := url.Parse(agentURL)
 	if err != nil {
 		return nil, err
 	}
-	return &agentClient{
+	client := &agentClient{
 		c:        &http.Client{},
 		agentURL: url,
-	}, nil
+	}
+	if _, err := client.GetInfo(); err != nil {
+		return client, err
+	}
+
+	return client, nil
 }
 
-func (a *agentClient) GetProcesses() (agent.Processes, error) {
-	processes := agent.Processes{}
-	return processes, nil
-}
-
-func (a *agentClient) GetInfo() (*agent.Info, error) {
-	agentInfo := agent.Info{}
-	return &agentInfo, nil
+func (a *agentClient) CreateLink(process string, linkHash *types.Bytes32, action string, refs []SegmentRef, args ...string) (*cs.Segment, error) {
+	seg := cs.Segment{}
+	return &seg, nil
 }
 
 func (a *agentClient) CreateMap(process string, refs []SegmentRef, args ...string) (*cs.Segment, error) {
@@ -75,22 +77,38 @@ func (a *agentClient) CreateMap(process string, refs []SegmentRef, args ...strin
 	return &seg, nil
 }
 
-func (a *agentClient) GetSegment(process string, linkHash types.Bytes32) (*cs.Segment, error) {
-	seg := cs.Segment{}
-	return &seg, nil
+func (a *agentClient) FindSegments(filter *store.SegmentFilter) (sgmts cs.SegmentSlice, err error) {
+	return a.findSegments(filter)
 }
 
-func (a *agentClient) FindSegments(filter *store.SegmentFilter) (cs.SegmentSlice, error) {
+func (a *agentClient) findSegments(filter *store.SegmentFilter) (cs.SegmentSlice, error) {
 	sgmts := cs.SegmentSlice{}
 	return sgmts, nil
+
 }
 
-func (a *agentClient) GetMapIds(filter *store.MapFilter) (cs.SegmentSlice, error) {
-	sgmts := cs.SegmentSlice{}
-	return sgmts, nil
+func (a *agentClient) GetInfo() (*agent.Info, error) {
+	agentInfo := agent.Info{}
+	return &agentInfo, nil
 }
 
-func (a *agentClient) CreateLink(process string, linkHash types.Bytes32, action string, refs []SegmentRef, args ...string) (*cs.Segment, error) {
+func (a *agentClient) GetMapIds(filter *store.MapFilter) (IDs []string, err error) {
+	return a.getMapIds(filter)
+}
+
+func (a *agentClient) getMapIds(filter *store.MapFilter) ([]string, error) {
+	return nil, nil
+}
+
+func (a *agentClient) GetProcess(name string) (*agent.Process, error) {
+	return nil, nil
+}
+
+func (a *agentClient) GetProcesses() (agent.Processes, error) {
+	processes := agent.Processes{}
+	return processes, nil
+}
+func (a *agentClient) GetSegment(process string, linkHash *types.Bytes32) (*cs.Segment, error) {
 	seg := cs.Segment{}
 	return &seg, nil
 }
@@ -100,22 +118,10 @@ func (a *agentClient) URL() string {
 	return a.agentURL.String()
 }
 
-func (a *agentClient) get(endpoint string) (*http.Response, error) {
-	path, err := url.Parse(endpoint)
-	if err != nil {
-		return nil, err
-	}
-	url := a.agentURL.ResolveReference(path)
-	return a.c.Get(url.String())
-
+func (a *agentClient) get(endpoint string, params interface{}) (*http.Response, error) {
+	return nil, nil
 }
 
 func (a *agentClient) post(endpoint string, data []byte) (*http.Response, error) {
-	path, err := url.Parse(endpoint)
-	if err != nil {
-		return nil, err
-	}
-	url := a.agentURL.ResolveReference(path)
-	return a.c.Post(url.String(), "application/json", bytes.NewBuffer(data))
-
+	return nil, nil
 }

--- a/agent/client/client.go
+++ b/agent/client/client.go
@@ -67,16 +67,22 @@ func NewAgentClient(agentURL string) (AgentClient, error) {
 	return client, nil
 }
 
+// CreateLink sends a CreateLink request to the agent and returns
+// the newly created segment
 func (a *agentClient) CreateLink(process string, linkHash *types.Bytes32, action string, refs []SegmentRef, args ...string) (*cs.Segment, error) {
 	seg := cs.Segment{}
 	return &seg, nil
 }
 
+// CreateMap sends a CreateMap request to the agent and returns
+// the first segment of the newly created map
 func (a *agentClient) CreateMap(process string, refs []SegmentRef, args ...string) (*cs.Segment, error) {
 	seg := cs.Segment{}
 	return &seg, nil
 }
 
+// FindSegments sends a FindSegments request to the agent and returns
+// the list of found segments
 func (a *agentClient) FindSegments(filter *store.SegmentFilter) (sgmts cs.SegmentSlice, err error) {
 	return a.findSegments(filter)
 }
@@ -87,11 +93,14 @@ func (a *agentClient) findSegments(filter *store.SegmentFilter) (cs.SegmentSlice
 
 }
 
+// GetInfo sends a GetInfo request to the agent and returns the result
 func (a *agentClient) GetInfo() (*agent.Info, error) {
 	agentInfo := agent.Info{}
 	return &agentInfo, nil
 }
 
+// GetMapIds sends a GetMapIds request to the agent and returns
+// a list of found map IDs for a process
 func (a *agentClient) GetMapIds(filter *store.MapFilter) (IDs []string, err error) {
 	return a.getMapIds(filter)
 }
@@ -100,28 +109,36 @@ func (a *agentClient) getMapIds(filter *store.MapFilter) ([]string, error) {
 	return nil, nil
 }
 
+// GetProcess returns a process given its name
 func (a *agentClient) GetProcess(name string) (*agent.Process, error) {
 	return nil, nil
 }
 
+// GetProcesses sends a GetProcesses request to the agent and returns
+// a list of all the processes
 func (a *agentClient) GetProcesses() (agent.Processes, error) {
 	processes := agent.Processes{}
 	return processes, nil
 }
+
+// GetSegment sends a GetSegment request to the agent and returns a segment
+// given its link hash
 func (a *agentClient) GetSegment(process string, linkHash *types.Bytes32) (*cs.Segment, error) {
 	seg := cs.Segment{}
 	return &seg, nil
 }
 
-// URL returns the url of the AgentClient
+// URL returns the url of the agent
 func (a *agentClient) URL() string {
 	return a.agentURL.String()
 }
 
+// get sends an HTTP GET request and checks the status of the response
 func (a *agentClient) get(endpoint string, params interface{}) (*http.Response, error) {
 	return nil, nil
 }
 
+// post sends an HTTP POST request and checks the status of the response
 func (a *agentClient) post(endpoint string, data []byte) (*http.Response, error) {
 	return nil, nil
 }

--- a/agent/client/client_test.go
+++ b/agent/client/client_test.go
@@ -2,9 +2,7 @@ package client_test
 
 import (
 	"flag"
-	"fmt"
 	"testing"
-	"time"
 
 	"github.com/stratumn/sdk/agent/agenttestcases"
 	"github.com/stratumn/sdk/agent/client"
@@ -17,8 +15,6 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	seed := int64(time.Now().Nanosecond())
-	fmt.Printf("using seed %d\n", seed)
 	flag.Parse()
 	m.Run()
 }

--- a/agent/client/client_test.go
+++ b/agent/client/client_test.go
@@ -1,28 +1,65 @@
 package client_test
 
 import (
+	"flag"
+	"fmt"
+	"math/rand"
 	"testing"
+	"time"
 
+	"github.com/stratumn/sdk/agent/agenttestcases"
 	"github.com/stratumn/sdk/agent/client"
 	"github.com/stretchr/testify/assert"
 )
 
-var agentURL = "http://localhost:3000"
+var (
+	agentURL    = "http://localhost:3000"
+	integration = flag.Bool("integration", false, "Run integration tests")
+)
 
+func TestMain(m *testing.M) {
+	seed := int64(time.Now().Nanosecond())
+	fmt.Printf("using seed %d\n", seed)
+	rand.Seed(seed)
+	flag.Parse()
+	m.Run()
+}
 func TestNewAgentClient(t *testing.T) {
+	if *integration == false {
+		srv := mockAgentServer(t, agentURL)
+		defer srv.Shutdown(nil)
+	}
 	client, err := client.NewAgentClient(agentURL)
 	assert.NoError(t, err)
 	assert.Equal(t, agentURL, client.URL())
 }
 
-func TestNewAgentClient_DefaultURL(t *testing.T) {
-	client, err := client.NewAgentClient("")
+func TestNewAgentClient_ExtraSlash(t *testing.T) {
+	if *integration == false {
+		agentURL := "http://localhost:3000/"
+		srv := mockAgentServer(t, agentURL)
+		defer srv.Shutdown(nil)
+	}
+	client, err := client.NewAgentClient(agentURL)
 	assert.NoError(t, err)
-	assert.Equal(t, "http://agent:3000", client.URL())
+	assert.Equal(t, agentURL, client.URL())
 }
 
 func TestNewAgentClient_WrongURL(t *testing.T) {
 	agentURL := "//http:\\"
 	_, err := client.NewAgentClient(agentURL)
 	assert.EqualError(t, err, "parse //http:\\: invalid character \"\\\\\" in host name")
+}
+
+func TestAgentClient(t *testing.T) {
+	mockServer := mockAgentServer
+	if *integration == true {
+		mockServer = nil
+	}
+	agenttestcases.Factory{
+		NewClient: func(agentURL string) (client.AgentClient, error) {
+			return client.NewAgentClient(agentURL)
+		},
+		NewMock: mockServer,
+	}.RunAgentClientTests(t)
 }

--- a/agent/client/client_test.go
+++ b/agent/client/client_test.go
@@ -3,7 +3,6 @@ package client_test
 import (
 	"flag"
 	"fmt"
-	"math/rand"
 	"testing"
 	"time"
 
@@ -20,7 +19,6 @@ var (
 func TestMain(m *testing.M) {
 	seed := int64(time.Now().Nanosecond())
 	fmt.Printf("using seed %d\n", seed)
-	rand.Seed(seed)
 	flag.Parse()
 	m.Run()
 }

--- a/agent/client/client_test.go
+++ b/agent/client/client_test.go
@@ -24,6 +24,8 @@ func TestMain(m *testing.M) {
 	flag.Parse()
 	m.Run()
 }
+
+// TestNewAgentClient checks the initialisation of a new client
 func TestNewAgentClient(t *testing.T) {
 	if *integration == false {
 		srv := mockAgentServer(t, agentURL)
@@ -34,6 +36,8 @@ func TestNewAgentClient(t *testing.T) {
 	assert.Equal(t, agentURL, client.URL())
 }
 
+// TestNewAgentClient_ExtraSlash tests if the client handles correctly
+// the connection when the url ends with and extra '/'
 func TestNewAgentClient_ExtraSlash(t *testing.T) {
 	if *integration == false {
 		agentURL := "http://localhost:3000/"
@@ -45,12 +49,15 @@ func TestNewAgentClient_ExtraSlash(t *testing.T) {
 	assert.Equal(t, agentURL, client.URL())
 }
 
+// TestNewAgentClient_WrongURL tests the error handling when the
+// provided url is ill formatted
 func TestNewAgentClient_WrongURL(t *testing.T) {
 	agentURL := "//http:\\"
 	_, err := client.NewAgentClient(agentURL)
 	assert.EqualError(t, err, "parse //http:\\: invalid character \"\\\\\" in host name")
 }
 
+// TestAgentClient runs all the tests for the client
 func TestAgentClient(t *testing.T) {
 	mockServer := mockAgentServer
 	if *integration == true {

--- a/agent/client/utils_test.go
+++ b/agent/client/utils_test.go
@@ -3,43 +3,272 @@ package client_test
 import (
 	"encoding/json"
 	"net/http"
+	"path/filepath"
+	"strconv"
+	"strings"
 	"testing"
 
+	log "github.com/sirupsen/logrus"
+
 	"github.com/golang/mock/gomock"
+	"github.com/gorilla/mux"
 	"github.com/stratumn/sdk/agent"
+	"github.com/stratumn/sdk/agent/client"
+	"github.com/stratumn/sdk/cs"
 )
 
 type mockHTTPServer struct{}
 
-func (m *mockHTTPServer) sendResponse(w http.ResponseWriter, data interface{}) {
-	js, err := json.Marshal(data)
+func (a *mockHTTPServer) decodePostParams(r *http.Request) ([]interface{}, error) {
+	decoder := json.NewDecoder(r.Body)
+	params := []interface{}{}
+	if err := decoder.Decode(&params); err != nil {
+		return nil, err
+	}
+	return params, nil
+}
+
+func (m *mockHTTPServer) sendError(w http.ResponseWriter, status int, message string) {
+	errorData := client.ErrorData{
+		Status:  status,
+		Message: message,
+	}
+	bytes, err := json.Marshal(errorData)
 	if err != nil {
 		w.WriteHeader(500)
+		return
 	}
+	w.WriteHeader(status)
 	w.Header().Set("Content-Type", "application/json")
-	w.Write(js)
+	w.Write(bytes)
+}
+
+func (m *mockHTTPServer) sendResponse(w http.ResponseWriter, status int, data interface{}) {
+	bytes, err := json.Marshal(data)
+	if err != nil {
+		w.WriteHeader(500)
+		return
+	}
+	w.WriteHeader(status)
+	w.Header().Set("Content-Type", "application/json")
+	w.Write(bytes)
+}
+
+func (m *mockHTTPServer) mockCreateLink(w http.ResponseWriter, r *http.Request) {
+	params, err := m.decodePostParams(r)
+	if err != nil {
+		m.sendError(w, 400, err.Error())
+		return
+	}
+	if len(params) < 2 {
+		m.sendError(w, 400, "a title is required")
+		return
+	}
+	refs := params[0]
+	arg := params[1].(string)
+
+	vars := mux.Vars(r)
+	if vars["linkHash"] == "0000000000000000000000000000000000000000000000000000000000000000" {
+		m.sendError(w, 400, "Not Found")
+		return
+	} else if vars["action"] == "wrong" {
+		m.sendError(w, 400, "not found")
+		return
+	} else if vars["process"] == "wrong" {
+		m.sendError(w, 400, "process 'wrong' does not exist")
+		return
+	} else if vars["process"] == "wrongref" {
+		m.sendError(w, 400, "missing segment or (process and linkHash)")
+		return
+	}
+
+	s := cs.Segment{
+		Link: cs.Link{
+			State: map[string]interface{}{
+				"title": arg,
+			},
+			Meta: map[string]interface{}{
+				"mapId": "mapId",
+				"refs":  refs,
+			},
+		},
+	}
+	m.sendResponse(w, 200, &s)
+}
+
+func (m *mockHTTPServer) mockCreateMap(w http.ResponseWriter, r *http.Request) {
+	params, err := m.decodePostParams(r)
+	if err != nil {
+		m.sendError(w, 400, err.Error())
+		return
+	}
+	if len(params) < 2 {
+		m.sendError(w, 400, "a title is required")
+		return
+	}
+	refs := params[0]
+	arg := params[1].(string)
+
+	vars := mux.Vars(r)
+	if vars["process"] == "wrongref" {
+		m.sendError(w, 400, "missing segment or (process and linkHash)")
+		return
+	}
+	s := cs.Segment{
+		Link: cs.Link{
+			State: map[string]interface{}{
+				"title": arg,
+			},
+			Meta: map[string]interface{}{
+				"mapId": "mapId",
+				"refs":  refs,
+			},
+		},
+	}
+	m.sendResponse(w, 200, s)
+}
+
+func (m *mockHTTPServer) mockFindSegments(w http.ResponseWriter, r *http.Request) {
+	var (
+		q             = r.URL.Query()
+		limit, _      = strconv.Atoi(q.Get("limit"))
+		linkHashesStr = append(q["linkHashes[]"], q["linkHashes%5B%5D"]...)
+		mapIDs        = append(q["mapIds[]"], q["mapIds%5B%5D"]...)
+	)
+	s := cs.SegmentSlice{}
+	vars := mux.Vars(r)
+	if vars["process"] == "wrong" {
+		m.sendError(w, 400, "process 'wrong' does not exist")
+		return
+	}
+	if len(linkHashesStr) > 0 || len(mapIDs) > 0 {
+		s = append(s, &cs.Segment{})
+	} else {
+		for i := 0; i < limit; i++ {
+			s = append(s, &cs.Segment{})
+		}
+	}
+	m.sendResponse(w, 200, s)
 }
 
 func (m *mockHTTPServer) mockGetInfo(w http.ResponseWriter, r *http.Request) {
-	p := agent.Info{}
-	m.sendResponse(w, p)
+	info := agent.Info{
+		Processes: agent.ProcessesMap{
+			"test": &agent.Process{},
+		},
+		Stores: []agent.StoreInfo{
+			agent.StoreInfo{
+				"url": "http://localhost:5000",
+			},
+		},
+		Fossilizers: []agent.FossilizerInfo{},
+		Plugins: []agent.PluginInfo{
+			agent.PluginInfo{
+				Name:        "Agent URL",
+				Description: "Saves in segment meta the URL that can be used to retrieve a segment.",
+				ID:          "1",
+			},
+			agent.PluginInfo{
+				Name:        "Action arguments",
+				Description: "Saves the action and its arguments in link meta information.",
+				ID:          "2",
+			},
+			agent.PluginInfo{
+				Name:        "State Hash",
+				Description: "Computes and adds the hash of the state in meta.",
+				ID:          "3",
+			},
+		},
+	}
+	m.sendResponse(w, 200, info)
 }
 
-func mockAgentHTTPServer(t *testing.T, address string) {
+func (m *mockHTTPServer) mockGetMapIds(w http.ResponseWriter, r *http.Request) {
+	var (
+		q         = r.URL.Query()
+		limit, _  = strconv.Atoi(q.Get("limit"))
+		offset, _ = strconv.Atoi(q.Get("offset"))
+	)
+	s := make([]string, 0)
+	vars := mux.Vars(r)
+	if vars["process"] == "wrong" {
+		m.sendError(w, 400, "process 'wrong' does not exist")
+		return
+	}
+	if offset > limit {
+		m.sendResponse(w, 200, s)
+		return
+	}
+	for i := 0; i < limit; i++ {
+		s = append(s, "mapID")
+	}
+	m.sendResponse(w, 200, s)
+}
+
+func (m *mockHTTPServer) mockGetProcesses(w http.ResponseWriter, r *http.Request) {
+	p := agent.Processes{}
+	p = append(p, &agent.Process{
+		Name: "test",
+		ProcessInfo: agent.ProcessInfo{
+			Actions: map[string]agent.ActionInfo{
+				"one": agent.ActionInfo{},
+				"two": agent.ActionInfo{},
+			},
+		}})
+	m.sendResponse(w, 200, p)
+}
+
+func (m *mockHTTPServer) mockGetSegment(w http.ResponseWriter, r *http.Request) {
+	s := cs.Segment{}
+	vars := mux.Vars(r)
+	if vars["linkHash"] == "0000000000000000000000000000000000000000000000000000000000000000" {
+		m.sendError(w, 404, "Not Found")
+		return
+	}
+	m.sendResponse(w, 200, s)
+}
+
+func mockAgent(t *testing.T, address string) *agent.MockAgent {
+	url := cleanURL(address)
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 
 	mockObj := agent.NewMockAgent(mockCtrl)
 	mockObj.EXPECT().HttpServer().DoAndReturn(func() *http.Server {
-		mux := http.NewServeMux()
+		mux := mux.NewRouter()
 		handler := mockHTTPServer{}
-		mux.HandleFunc("/", handler.mockGetInfo)
+		mux.HandleFunc("/", handler.mockGetInfo).Methods("GET")
+		mux.HandleFunc("/processes", handler.mockGetProcesses).Methods("GET")
+		mux.HandleFunc("/{process}/segments", handler.mockCreateMap).Methods("POST")
+		mux.HandleFunc("/{process}/segments/{linkHash}/{action}", handler.mockCreateLink).Methods("POST")
+		mux.HandleFunc("/{process}/segments/{linkHash}", handler.mockGetSegment).Methods("GET")
+		mux.HandleFunc("/{process}/maps", handler.mockGetMapIds).Methods("GET")
+		mux.HandleFunc("/{process}/segments", handler.mockFindSegments).Methods("GET")
 		return &http.Server{
-			Addr:    ":3000",
+			Addr:    url,
 			Handler: mux,
 		}
-	}).Times(1)
+	}).AnyTimes()
+	return mockObj
+}
 
-	server := mockObj.HttpServer()
-	go server.ListenAndServe()
+func cleanURL(address string) string {
+	if strings.Contains(address, "http://") {
+		address = address[7:]
+	}
+	return filepath.Clean(address)
+
+}
+
+func mockAgentServer(t *testing.T, agentURL string) *http.Server {
+	server := mockAgent(t, agentURL).HttpServer()
+
+	go func() {
+		log.Info("Listening on ", agentURL, "...")
+		if err := server.ListenAndServe(); err != nil {
+			log.WithField("info", err).Info("Server stopped")
+			return
+		}
+	}()
+	return server
 }

--- a/agent/client/utils_test.go
+++ b/agent/client/utils_test.go
@@ -57,11 +57,11 @@ func (m *mockHTTPServer) sendResponse(w http.ResponseWriter, status int, data in
 func (m *mockHTTPServer) mockCreateLink(w http.ResponseWriter, r *http.Request) {
 	params, err := m.decodePostParams(r)
 	if err != nil {
-		m.sendError(w, 400, err.Error())
+		m.sendError(w, http.StatusOK, err.Error())
 		return
 	}
 	if len(params) < 2 {
-		m.sendError(w, 400, "a title is required")
+		m.sendError(w, http.StatusOK, "a title is required")
 		return
 	}
 	refs := params[0]
@@ -69,16 +69,16 @@ func (m *mockHTTPServer) mockCreateLink(w http.ResponseWriter, r *http.Request) 
 
 	vars := mux.Vars(r)
 	if vars["linkHash"] == "0000000000000000000000000000000000000000000000000000000000000000" {
-		m.sendError(w, 400, "Not Found")
+		m.sendError(w, http.StatusOK, "Not Found")
 		return
 	} else if vars["action"] == "wrong" {
-		m.sendError(w, 400, "not found")
+		m.sendError(w, http.StatusOK, "not found")
 		return
 	} else if vars["process"] == "wrong" {
-		m.sendError(w, 400, "process 'wrong' does not exist")
+		m.sendError(w, http.StatusOK, "process 'wrong' does not exist")
 		return
 	} else if vars["process"] == "wrongref" {
-		m.sendError(w, 400, "missing segment or (process and linkHash)")
+		m.sendError(w, http.StatusOK, "missing segment or (process and linkHash)")
 		return
 	}
 
@@ -99,11 +99,11 @@ func (m *mockHTTPServer) mockCreateLink(w http.ResponseWriter, r *http.Request) 
 func (m *mockHTTPServer) mockCreateMap(w http.ResponseWriter, r *http.Request) {
 	params, err := m.decodePostParams(r)
 	if err != nil {
-		m.sendError(w, 400, err.Error())
+		m.sendError(w, http.StatusOK, err.Error())
 		return
 	}
 	if len(params) < 2 {
-		m.sendError(w, 400, "a title is required")
+		m.sendError(w, http.StatusOK, "a title is required")
 		return
 	}
 	refs := params[0]
@@ -111,7 +111,7 @@ func (m *mockHTTPServer) mockCreateMap(w http.ResponseWriter, r *http.Request) {
 
 	vars := mux.Vars(r)
 	if vars["process"] == "wrongref" {
-		m.sendError(w, 400, "missing segment or (process and linkHash)")
+		m.sendError(w, http.StatusOK, "missing segment or (process and linkHash)")
 		return
 	}
 	s := cs.Segment{
@@ -138,7 +138,7 @@ func (m *mockHTTPServer) mockFindSegments(w http.ResponseWriter, r *http.Request
 	s := cs.SegmentSlice{}
 	vars := mux.Vars(r)
 	if vars["process"] == "wrong" {
-		m.sendError(w, 400, "process 'wrong' does not exist")
+		m.sendError(w, http.StatusOK, "process 'wrong' does not exist")
 		return
 	}
 	if len(linkHashesStr) > 0 || len(mapIDs) > 0 {
@@ -192,7 +192,7 @@ func (m *mockHTTPServer) mockGetMapIds(w http.ResponseWriter, r *http.Request) {
 	s := make([]string, 0)
 	vars := mux.Vars(r)
 	if vars["process"] == "wrong" {
-		m.sendError(w, 400, "process 'wrong' does not exist")
+		m.sendError(w, http.StatusOK, "process 'wrong' does not exist")
 		return
 	}
 	if offset > limit {
@@ -222,7 +222,7 @@ func (m *mockHTTPServer) mockGetSegment(w http.ResponseWriter, r *http.Request) 
 	s := cs.Segment{}
 	vars := mux.Vars(r)
 	if vars["linkHash"] == "0000000000000000000000000000000000000000000000000000000000000000" {
-		m.sendError(w, 404, "Not Found")
+		m.sendError(w, http.StatusNotFound, "Not Found")
 		return
 	}
 	m.sendResponse(w, 200, s)

--- a/agent/client/utils_test.go
+++ b/agent/client/utils_test.go
@@ -35,7 +35,7 @@ func (m *mockHTTPServer) sendError(w http.ResponseWriter, status int, message st
 	}
 	bytes, err := json.Marshal(errorData)
 	if err != nil {
-		w.WriteHeader(500)
+		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
 	w.WriteHeader(status)
@@ -46,7 +46,7 @@ func (m *mockHTTPServer) sendError(w http.ResponseWriter, status int, message st
 func (m *mockHTTPServer) sendResponse(w http.ResponseWriter, status int, data interface{}) {
 	bytes, err := json.Marshal(data)
 	if err != nil {
-		w.WriteHeader(500)
+		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
 	w.WriteHeader(status)

--- a/agent/plugin.go
+++ b/agent/plugin.go
@@ -7,6 +7,7 @@ import "github.com/stratumn/sdk/cs"
 type PluginInfo struct {
 	Name        string `json:"name"`
 	Description string `json:"description"`
+	ID          string `json:"id"`
 }
 
 // Plugin is the interface describing the handlers that a plugin can implement
@@ -25,4 +26,4 @@ type Plugin interface {
 }
 
 // Plugins is a list of Plugin
-type Plugins []Plugin
+type Plugins []PluginInfo

--- a/agent/process.go
+++ b/agent/process.go
@@ -20,3 +20,16 @@ type Process struct {
 
 // Processes is a list of Process
 type Processes []*Process
+
+// ProcessesMap is a mapping of processes indexed by name
+type ProcessesMap map[string]*Process
+
+// FindProcess returns the process whose name matches the provided one
+func (p Processes) FindProcess(name string) *Process {
+	for _, process := range p {
+		if process.Name == name {
+			return process
+		}
+	}
+	return nil
+}

--- a/store/store.go
+++ b/store/store.go
@@ -118,10 +118,10 @@ type KeyValueStore interface {
 // Pagination contains pagination options.
 type Pagination struct {
 	// Index of the first entry.
-	Offset int `json:"offset"`
+	Offset int `json:"offset" url:"offset"`
 
 	// Maximum number of entries.
-	Limit int `json:"limit"`
+	Limit int `json:"limit" url:"limit"`
 }
 
 // SegmentFilter contains filtering options for segments.
@@ -131,22 +131,22 @@ type SegmentFilter struct {
 	Pagination `json:"pagination"`
 
 	// Map IDs the segments must have.
-	MapIDs []string `json:"mapIds"`
+	MapIDs []string `json:"mapIds" url:"mapIds,brackets"`
 
 	// Process name is optionnal.
-	Process string `json:"process"`
+	Process string `json:"process" url:"-"`
 
 	// A previous link hash the segments must have.
 	// nil makes this attribute as optional
 	// empty string is to search Segments without parent
-	PrevLinkHash *string `json:"prevLinkHash"`
+	PrevLinkHash *string `json:"prevLinkHash" url:"prevLinkHash"`
 
 	// A slice of linkHashes to search Segments.
 	// This attribute is optional.
-	LinkHashes []string `json:"linkHashes"`
+	LinkHashes []string `json:"linkHashes" url:"linkHashes,brackets"`
 
 	// A slice of tags the segments must all contain.
-	Tags []string `json:"tags"`
+	Tags []string `json:"tags" url:"tags"`
 }
 
 // MapFilter contains filtering options for segments.
@@ -154,7 +154,7 @@ type MapFilter struct {
 	Pagination `json:"pagination"`
 
 	// Process name is optionnal.
-	Process string `json:"process"`
+	Process string `json:"process" url:"-"`
 }
 
 // PaginateStrings paginates a list of strings


### PR DESCRIPTION
This is the second part of the agent-client (there are three in total).
It contains mainly two things : 
- a mock for the agent and its http server (I had to add an extra dependency to gorilla/mux for the router, because the one we are using in `storehttp` [does not support the agent's routes](https://github.com/julienschmidt/httprouter/issues/12))
- the testing package layout for the agent-client, It lives in its own sub-package because I felt it could be somehow shared with the agent tests but I did not figure out how exactly (I'm open to suggestions here)

Next PR will be actual implementation !

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stratumn/sdk/297)
<!-- Reviewable:end -->
