### PR TITLE
couchstore: retry only if couchdb unavailable and create system dbs

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -471,6 +471,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "7793c5d193a26dd68987b2de4a3ad02b05a1a840b411f38c462dc0a30185c8c6"
+  inputs-digest = "cc1155e2ec87d1e9430cbc3a3f67c176d1d2a5e92e66deddae1b7e6e81ae31a7"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/cmd/couchstore/main.go
+++ b/cmd/couchstore/main.go
@@ -51,13 +51,17 @@ func main() {
 			Commit:  commit,
 		})
 
-		if storeErr != nil {
+		if storeErr == nil {
+			return false, nil
+		}
+
+		if _, ok := storeErr.(*couchstore.CouchNotReadyError); ok {
 			log.Infof("Unable to connect to couchdb (%v). Retrying in 5s.", storeErr.Error())
 			time.Sleep(5 * time.Second)
 			return true, storeErr
 		}
 
-		return false, nil
+		return false, storeErr
 	}, 10)
 
 	if err != nil {

--- a/couchstore/api.go
+++ b/couchstore/api.go
@@ -100,9 +100,11 @@ func (c *CouchStore) createDatabase(dbName string) error {
 	}
 
 	if couchResponseStatus.Ok == false {
-		if couchResponseStatus.StatusCode != statusDBExists {
-			return couchResponseStatus.error()
+		if couchResponseStatus.StatusCode == statusDBExists {
+			return nil
 		}
+
+		return couchResponseStatus.error()
 	}
 
 	return utils.Retry(func(attempt int) (bool, error) {


### PR DESCRIPTION
- couchstore retries connecting to couchdb only if couchdb is unavailable not for other errors
- couchstore creates _users and _replicator required dbs in couchdb if they don't already exist

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stratumn/sdk/320)
<!-- Reviewable:end -->
