### PR TITLE
agent/client: add uploadprocess endpoint

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -34,6 +34,7 @@ type ProcessOptions struct {
 // Agent is the interface of an agent
 type Agent interface {
 	AddProcess(process string, actions Actions, storeClient interface{}, fossilizerClients []interface{}, opts *ProcessOptions) (Process, error)
+	UploadProcess(processName string, actionsPath string, storeURL string, fossilizerURLs []string, pluginIDs []string) (*Process, error)
 	FindSegments(filter store.SegmentFilter) (cs.SegmentSlice, error)
 	GetInfo() (*Info, error)
 	GetMapIds(filter store.MapFilter) ([]string, error)

--- a/agent/agenttestcases/actions.js
+++ b/agent/agenttestcases/actions.js
@@ -1,0 +1,35 @@
+module.exports = {
+    events: {
+      didSave: function(segment) {
+        console.log("Segment " + segment.meta.linkHash + " was saved!");
+      }
+    },
+  
+    name: "test",
+  
+    init: function(title) {
+      if (!title) {
+        return this.reject("a title is required");
+      }
+  
+      this.state = {
+        title: title
+      };
+  
+      this.meta.tags = [title];
+      console.log("now is", this);
+      this.append();
+    },
+  
+    test: function(title) {
+      if (!title) {
+        return this.reject("a title is required");
+      }
+  
+      this.state = {
+        title: title
+      };
+  
+      this.append();
+    }
+  };

--- a/agent/agenttestcases/agenttestcases.go
+++ b/agent/agenttestcases/agenttestcases.go
@@ -12,6 +12,9 @@ import (
 
 var agentURL = "http://localhost:3000"
 
+// StoreURL is used to connect to the agent underlying store.
+const StoreURL = "http://store:5000"
+
 // Factory wraps functions to create a client and a mock agent.
 // After its creation, the client is stored in the factory to avoid
 // re-creating it in every test.
@@ -35,6 +38,7 @@ func (f Factory) RunAgentClientTests(t *testing.T) {
 	}
 	f.Client, _ = f.NewClient(agentURL)
 
+	t.Run("TestUploadProcess", f.TestUploadProcess)
 	t.Run("Test creating map", f.TestCreateMap)
 	t.Run("Test creating segment", f.TestCreateSegment)
 	t.Run("Test find segments", f.TestFindSegments)
@@ -42,6 +46,11 @@ func (f Factory) RunAgentClientTests(t *testing.T) {
 	t.Run("Test getting a process", f.TestGetProcess)
 	t.Run("Test getting all the processes", f.TestGetProcesses)
 	t.Run("Test getting a segment", f.TestGetSegment)
+}
+
+// TestUploadProcess tests what happens when uploading a process with various inputs.
+func (f Factory) TestUploadProcess(t *testing.T) {
+	t.Run("TestUploadProcessOK", f.TestUploadProcessOK)
 }
 
 // TestCreateMap tests what happens when creating a map with various inputs.

--- a/agent/agenttestcases/getinfo.go
+++ b/agent/agenttestcases/getinfo.go
@@ -17,27 +17,11 @@ func (f Factory) TestGetInfoOK(t *testing.T) {
 		},
 		Stores: []agent.StoreInfo{
 			agent.StoreInfo{
-				"url": "http://localhost:5000",
+				"url": StoreURL,
 			},
 		},
 		Fossilizers: []agent.FossilizerInfo{},
-		Plugins: []agent.PluginInfo{
-			agent.PluginInfo{
-				Name:        "Agent URL",
-				Description: "Saves in segment meta the URL that can be used to retrieve a segment.",
-				ID:          "1",
-			},
-			agent.PluginInfo{
-				Name:        "Action arguments",
-				Description: "Saves the action and its arguments in link meta information.",
-				ID:          "2",
-			},
-			agent.PluginInfo{
-				Name:        "State Hash",
-				Description: "Computes and adds the hash of the state in meta.",
-				ID:          "3",
-			},
-		},
+		Plugins:     []agent.PluginInfo{},
 	}
 	assert.NoError(t, err)
 	assert.NotNil(t, actual)

--- a/agent/agenttestcases/uploadprocess.go
+++ b/agent/agenttestcases/uploadprocess.go
@@ -1,7 +1,8 @@
 package agenttestcases
 
 import (
-	"os"
+	"fmt"
+	"go/build"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -14,7 +15,7 @@ import (
 func (f Factory) TestUploadProcessOK(t *testing.T) {
 	process, err := f.Client.UploadProcess(
 		"test",
-		os.Getenv("GOPATH")+"/src/github.com/stratumn/sdk/agent/agenttestcases/actions.js",
+		fmt.Sprintf("%v/src/github.com/stratumn/sdk/agent/agenttestcases/actions.js", build.Default.GOPATH),
 		StoreURL,
 		[]string{},
 		[]string{},

--- a/agent/agenttestcases/uploadprocess.go
+++ b/agent/agenttestcases/uploadprocess.go
@@ -1,0 +1,25 @@
+package agenttestcases
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Don't forget to set enableProcessUpload to true on the agent to test
+// this feature.
+
+// TestUploadProcessOK tests the client's ability to handle a CreateMap request.
+func (f Factory) TestUploadProcessOK(t *testing.T) {
+	process, err := f.Client.UploadProcess(
+		"test",
+		os.Getenv("GOPATH")+"/src/github.com/stratumn/sdk/agent/agenttestcases/actions.js",
+		StoreURL,
+		[]string{},
+		[]string{},
+	)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, process)
+}

--- a/agent/mock.go
+++ b/agent/mock.go
@@ -56,7 +56,7 @@ func (m *MockAgent) UploadProcess(processName string, actionsPath string, storeU
 	return ret0, ret1
 }
 
-// AddProcess indicates an expected call of AddProcess
+// UploadProcess indicates an expected call of AddProcess
 func (mr *MockAgentMockRecorder) UploadProcess(processName, actionsPath, storeURL, fossilizerURLs, pluginIDs interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UploadProcess", reflect.TypeOf((*MockAgent)(nil).UploadProcess), processName, actionsPath, storeURL, fossilizerURLs, pluginIDs)
 }

--- a/agent/mock.go
+++ b/agent/mock.go
@@ -48,6 +48,19 @@ func (mr *MockAgentMockRecorder) AddProcess(process, actions, storeClient, fossi
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddProcess", reflect.TypeOf((*MockAgent)(nil).AddProcess), process, actions, storeClient, fossilizerClients, opts)
 }
 
+// UploadProcess mocks base method
+func (m *MockAgent) UploadProcess(processName string, actionsPath string, storeURL string, fossilizerURLs []string, pluginIDs []string) (*Process, error) {
+	ret := m.ctrl.Call(m, "UploadProcess", processName, actionsPath, storeURL, fossilizerURLs, pluginIDs)
+	ret0, _ := ret[0].(*Process)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// AddProcess indicates an expected call of AddProcess
+func (mr *MockAgentMockRecorder) UploadProcess(processName, actionsPath, storeURL, fossilizerURLs, pluginIDs interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UploadProcess", reflect.TypeOf((*MockAgent)(nil).UploadProcess), processName, actionsPath, storeURL, fossilizerURLs, pluginIDs)
+}
+
 // FindSegments mocks base method
 func (m *MockAgent) FindSegments(process string, opts map[string]string) (cs.SegmentSlice, error) {
 	ret := m.ctrl.Call(m, "FindSegments", process, opts)


### PR DESCRIPTION
Agent client can now upload a process to the agent. When launching integration tests for agent/client spin up an agent with no processes and a store. The action.js file will be used to create the test process.

I've removed the plugins as the process is launched with no plugins.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stratumn/sdk/322)
<!-- Reviewable:end -->
