### PR TITLE
batchfossilizer: stop does not reset transformer

### DIFF
--- a/batchfossilizer/batchfossilizer.go
+++ b/batchfossilizer/batchfossilizer.go
@@ -417,7 +417,6 @@ func (a *Fossilizer) stop(err error) error {
 	}
 
 	a.waitGroup.Wait()
-	a.SetTransformer(nil)
 
 	if a.pending.file != nil {
 		if e := a.pending.file.Close(); e != nil {


### PR DESCRIPTION
It's useful to keep the transformer when stopping/restarting a fossilizer

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stratumn/sdk/328)
<!-- Reviewable:end -->
