### PR TITLE
postgresstore: sort mapIds by last update

### DIFF
--- a/postgresstore/stmts.go
+++ b/postgresstore/stmts.go
@@ -148,9 +148,10 @@ const (
 		OFFSET $4 LIMIT $5
 	`
 	sqlGetMapIDs = `
-		SELECT DISTINCT map_id FROM links
+		SELECT l.map_id FROM links l
 		WHERE (length($3) = 0 OR process = $3)
-		ORDER BY map_id
+		GROUP BY l.map_id
+		ORDER BY MAX(l.updated_at) DESC
 		OFFSET $1 LIMIT $2
 	`
 	sqlSaveValue = `


### PR DESCRIPTION
This commit changes the way map ids are ordered by the postgresstore. I didn't add any test since this behavior isn't specified by the store interface, and other stores may sort segments and map ids in a different manner.

I created a card (#333) to add a `Sort` object to customize the sorting method used in `FindSegments` and `GetMapIds`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stratumn/sdk/334)
<!-- Reviewable:end -->
