### PR TITLE
validator, cs: add signature type and signature validator

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -3,15 +3,33 @@
 
 [[projects]]
   name = "docker.io/go-docker"
-  packages = [".","api","api/types","api/types/blkiodev","api/types/container","api/types/events","api/types/filters","api/types/image","api/types/mount","api/types/network","api/types/registry","api/types/strslice","api/types/swarm","api/types/swarm/runtime","api/types/time","api/types/versions","api/types/volume"]
+  packages = [
+    ".",
+    "api",
+    "api/types",
+    "api/types/blkiodev",
+    "api/types/container",
+    "api/types/events",
+    "api/types/filters",
+    "api/types/image",
+    "api/types/mount",
+    "api/types/network",
+    "api/types/registry",
+    "api/types/strslice",
+    "api/types/swarm",
+    "api/types/swarm/runtime",
+    "api/types/time",
+    "api/types/versions",
+    "api/types/volume"
+  ]
   revision = "b3f5b5de7bbce0acc6a7fc0a4c2b88db678e262e"
   version = "v1.0.0"
 
 [[projects]]
   name = "github.com/Microsoft/go-winio"
   packages = ["."]
-  revision = "78439966b38d69bf38227fbf57ac8a6fee70f69a"
-  version = "v0.4.5"
+  revision = "7da180ee92d8bd8bb8c37fc560e673e6557c392f"
+  version = "v0.4.7"
 
 [[projects]]
   name = "github.com/blockcypher/gobcy"
@@ -22,8 +40,14 @@
 [[projects]]
   branch = "master"
   name = "github.com/btcsuite/btcd"
-  packages = ["btcec","chaincfg","chaincfg/chainhash","txscript","wire"]
-  revision = "2e60448ffcc6bf78332d1fe590260095f554dd78"
+  packages = [
+    "btcec",
+    "chaincfg",
+    "chaincfg/chainhash",
+    "txscript",
+    "wire"
+  ]
+  revision = "9aa9e79ebf7f11f1f70533c100e5c835a6af8c0f"
 
 [[projects]]
   branch = "master"
@@ -34,7 +58,11 @@
 [[projects]]
   branch = "master"
   name = "github.com/btcsuite/btcutil"
-  packages = [".","base58","bech32"]
+  packages = [
+    ".",
+    "base58",
+    "bech32"
+  ]
   revision = "501929d3d046174c3d39f0ea54ece471aa17238c"
 
 [[projects]]
@@ -51,12 +79,19 @@
 
 [[projects]]
   name = "github.com/docker/distribution"
-  packages = ["digestset","reference"]
+  packages = [
+    "digestset",
+    "reference"
+  ]
   revision = "edc3ab29cdff8694dd6feb85cfeb4b5f1b38ed9c"
 
 [[projects]]
   name = "github.com/docker/go-connections"
-  packages = ["nat","sockets","tlsconfig"]
+  packages = [
+    "nat",
+    "sockets",
+    "tlsconfig"
+  ]
   revision = "3ede32e2033de7505e6500d6c868c2b9ed9f169d"
   version = "v0.3.0"
 
@@ -75,8 +110,8 @@
 [[projects]]
   name = "github.com/fsnotify/fsnotify"
   packages = ["."]
-  revision = "629574ca2a5df945712d3079857300b5e4da0236"
-  version = "v1.4.2"
+  revision = "c2828203cd70a50dcccfb2761f8b1f8ceef9a8e9"
+  version = "v1.4.7"
 
 [[projects]]
   name = "github.com/gibson042/canonicaljson-go"
@@ -86,7 +121,11 @@
 
 [[projects]]
   name = "github.com/go-kit/kit"
-  packages = ["log","log/level","log/term"]
+  packages = [
+    "log",
+    "log/level",
+    "log/term"
+  ]
   revision = "4dc7be5d2d12881735283bcab7352178e190fc71"
   version = "v0.6.0"
 
@@ -98,7 +137,10 @@
 
 [[projects]]
   name = "github.com/go-playground/locales"
-  packages = [".","currency"]
+  packages = [
+    ".",
+    "currency"
+  ]
   revision = "e4cbcb5d0652150d40ad0646651076b6bd2be4f6"
   version = "v0.11.2"
 
@@ -116,7 +158,14 @@
 
 [[projects]]
   name = "github.com/gogo/protobuf"
-  packages = ["gogoproto","jsonpb","proto","protoc-gen-gogo/descriptor","sortkeys","types"]
+  packages = [
+    "gogoproto",
+    "jsonpb",
+    "proto",
+    "protoc-gen-gogo/descriptor",
+    "sortkeys",
+    "types"
+  ]
   revision = "342cbe0a04158f6dcb03ca0079991a51a4248c02"
   version = "v0.5"
 
@@ -124,13 +173,19 @@
   branch = "master"
   name = "github.com/golang/mock"
   packages = ["gomock"]
-  revision = "f67f7081ddcd0f92a20c1d58e7cd8b23253d15c7"
+  revision = "b3e60bcdc577185fce3cf625fc96b62857ce5574"
 
 [[projects]]
   branch = "master"
   name = "github.com/golang/protobuf"
-  packages = ["proto","ptypes","ptypes/any","ptypes/duration","ptypes/timestamp"]
-  revision = "1e59b77b52bf8e4b449a57e6f79f21226d571845"
+  packages = [
+    "proto",
+    "ptypes",
+    "ptypes/any",
+    "ptypes/duration",
+    "ptypes/timestamp"
+  ]
+  revision = "925541529c1fa6821df4e44ce2723319eb2be768"
 
 [[projects]]
   branch = "master"
@@ -142,7 +197,7 @@
   branch = "master"
   name = "github.com/google/go-github"
   packages = ["github"]
-  revision = "fbfee053c26dab3772adfc7799d995eed379133e"
+  revision = "e48060a28fac52d0f1cb758bc8b87c07bac4a87d"
 
 [[projects]]
   branch = "master"
@@ -159,8 +214,8 @@
 [[projects]]
   name = "github.com/gorilla/mux"
   packages = ["."]
-  revision = "7f08801859139f86dfafd1c296e2cba9a80d292e"
-  version = "v1.6.0"
+  revision = "53c1911da2b537f792e7cafcb446b05ffe33b996"
+  version = "v1.6.1"
 
 [[projects]]
   name = "github.com/gorilla/websocket"
@@ -177,7 +232,18 @@
 [[projects]]
   branch = "master"
   name = "github.com/hashicorp/hcl"
-  packages = [".","hcl/ast","hcl/parser","hcl/printer","hcl/scanner","hcl/strconv","hcl/token","json/parser","json/scanner","json/token"]
+  packages = [
+    ".",
+    "hcl/ast",
+    "hcl/parser",
+    "hcl/printer",
+    "hcl/scanner",
+    "hcl/strconv",
+    "hcl/token",
+    "json/parser",
+    "json/scanner",
+    "json/token"
+  ]
   revision = "23c074d0eceb2b8a5bfdbb271ab780cde70f05a8"
 
 [[projects]]
@@ -185,6 +251,12 @@
   packages = ["."]
   revision = "76626ae9c91c4f2a10f34cad8ce83ea42c93bb75"
   version = "v1.0"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/jmespath/go-jmespath"
+  packages = ["."]
+  revision = "dd801d4f4ce7ac746e7e7b4489d2fa600b3b096b"
 
 [[projects]]
   branch = "master"
@@ -213,14 +285,17 @@
 [[projects]]
   branch = "master"
   name = "github.com/lib/pq"
-  packages = [".","oid"]
-  revision = "83612a56d3dd153a94a629cd64925371c9adad78"
+  packages = [
+    ".",
+    "oid"
+  ]
+  revision = "19c8e9ad00952ce0c64489b60e8df88bb16dd514"
 
 [[projects]]
   name = "github.com/magiconair/properties"
   packages = ["."]
-  revision = "be5ece7dd465ab0765a9682137865547526d1dfb"
-  version = "v1.7.3"
+  revision = "d419a98cdbed11a922bf76f257b7c4be79b50e73"
+  version = "v1.7.4"
 
 [[projects]]
   branch = "master"
@@ -232,7 +307,7 @@
   branch = "master"
   name = "github.com/mitchellh/mapstructure"
   packages = ["."]
-  revision = "06020f85339e21b2478f756a78e295255ffa4d6a"
+  revision = "b4575eea38cca1123ec2dc90c26529b5c5acfcff"
 
 [[projects]]
   name = "github.com/opencontainers/go-digest"
@@ -242,15 +317,18 @@
 
 [[projects]]
   name = "github.com/opencontainers/image-spec"
-  packages = ["specs-go","specs-go/v1"]
+  packages = [
+    "specs-go",
+    "specs-go/v1"
+  ]
   revision = "d60099175f88c47cd379c4738d158884749ed235"
   version = "v1.0.1"
 
 [[projects]]
   name = "github.com/pelletier/go-toml"
   packages = ["."]
-  revision = "16398bac157da96aa88f98a2df640c7f32af1da2"
-  version = "v1.0.1"
+  revision = "acdc4509485b587f5e675510c4f2c63e90ff68a8"
+  version = "v1.1.0"
 
 [[projects]]
   name = "github.com/pkg/errors"
@@ -268,7 +346,7 @@
   branch = "master"
   name = "github.com/rcrowley/go-metrics"
   packages = ["."]
-  revision = "e181e095bae94582363434144c61a9653aff6e50"
+  revision = "8732c616f52954686704c8645fe1a9d59e9df7c1"
 
 [[projects]]
   name = "github.com/sirupsen/logrus"
@@ -278,9 +356,12 @@
 
 [[projects]]
   name = "github.com/spf13/afero"
-  packages = [".","mem"]
-  revision = "8d919cbe7e2627e417f3e45c3c0e489a5b7e2536"
-  version = "v1.0.0"
+  packages = [
+    ".",
+    "mem"
+  ]
+  revision = "bb8f1927f2a9d3ab41c9340aa034f6b803f4359c"
+  version = "v1.0.2"
 
 [[projects]]
   name = "github.com/spf13/cast"
@@ -292,13 +373,13 @@
   branch = "master"
   name = "github.com/spf13/cobra"
   packages = ["."]
-  revision = "ccaecb155a2177302cb56cae929251a256d0f646"
+  revision = "f91529fc609202eededff4de2dc0ba2f662240a3"
 
 [[projects]]
   branch = "master"
   name = "github.com/spf13/jwalterweatherman"
   packages = ["."]
-  revision = "12bd96e66386c1960ab0f74ced1362f66f552f7b"
+  revision = "7c0cea34c8ece3fbeb2b27ab9b59511d360fb394"
 
 [[projects]]
   name = "github.com/spf13/pflag"
@@ -310,36 +391,62 @@
   branch = "master"
   name = "github.com/spf13/viper"
   packages = ["."]
-  revision = "1a0c4a370c3e8286b835467d2dfcdaf636c3538b"
+  revision = "aafc9e6bc7b7bb53ddaa75a5ef49a17d6e654be5"
 
 [[projects]]
-  branch = "master"
   name = "github.com/stretchr/objx"
   packages = ["."]
-  revision = "1a9d0bb9f541897e62256577b352fdbc1fb4fd94"
+  revision = "facf9a85c22f48d2f52f2380e4efce1768749a89"
+  version = "v0.1"
 
 [[projects]]
   name = "github.com/stretchr/testify"
-  packages = ["assert","mock"]
-  revision = "69483b4bd14f5845b5a1e55bca19e954e827f1d0"
-  version = "v1.1.4"
+  packages = [
+    "assert",
+    "mock",
+    "require"
+  ]
+  revision = "b91bfb9ebec76498946beb6af7c0230c7cc7ba6c"
+  version = "v1.2.0"
 
 [[projects]]
   branch = "master"
   name = "github.com/syndtr/goleveldb"
-  packages = ["leveldb","leveldb/cache","leveldb/comparer","leveldb/errors","leveldb/filter","leveldb/iterator","leveldb/journal","leveldb/memdb","leveldb/opt","leveldb/storage","leveldb/table","leveldb/util"]
-  revision = "3d8f4155ffd9029d32e5cf03853b58759b6e3710"
+  packages = [
+    "leveldb",
+    "leveldb/cache",
+    "leveldb/comparer",
+    "leveldb/errors",
+    "leveldb/filter",
+    "leveldb/iterator",
+    "leveldb/journal",
+    "leveldb/memdb",
+    "leveldb/opt",
+    "leveldb/storage",
+    "leveldb/table",
+    "leveldb/util"
+  ]
+  revision = "211f780988068502fe874c44dae530528ebd840f"
 
 [[projects]]
   name = "github.com/tendermint/abci"
-  packages = ["client","example/code","example/dummy","types"]
+  packages = [
+    "client",
+    "example/code",
+    "example/dummy",
+    "types"
+  ]
   revision = "fca2b508c185b855af1446ec4afc19bdfc7b315d"
   version = "v0.8.0"
 
 [[projects]]
   branch = "master"
   name = "github.com/tendermint/ed25519"
-  packages = [".","edwards25519","extra25519"]
+  packages = [
+    ".",
+    "edwards25519",
+    "extra25519"
+  ]
   revision = "d8387025d2b9d158cf4efb07e7ebf814bcce2057"
 
 [[projects]]
@@ -350,7 +457,11 @@
 
 [[projects]]
   name = "github.com/tendermint/go-wire"
-  packages = [".","data","nowriter/tmlegacy"]
+  packages = [
+    ".",
+    "data",
+    "nowriter/tmlegacy"
+  ]
   revision = "b6fc872b42d41158a60307db4da051dd6f179415"
   version = "v0.7.2"
 
@@ -362,13 +473,50 @@
 
 [[projects]]
   name = "github.com/tendermint/tendermint"
-  packages = ["blockchain","config","consensus","consensus/types","mempool","node","p2p","p2p/trust","p2p/upnp","proxy","rpc/client","rpc/core","rpc/core/types","rpc/grpc","rpc/lib","rpc/lib/client","rpc/lib/server","rpc/lib/types","rpc/test","state","state/txindex","state/txindex/kv","state/txindex/null","types","version"]
+  packages = [
+    "blockchain",
+    "config",
+    "consensus",
+    "consensus/types",
+    "mempool",
+    "node",
+    "p2p",
+    "p2p/trust",
+    "p2p/upnp",
+    "proxy",
+    "rpc/client",
+    "rpc/core",
+    "rpc/core/types",
+    "rpc/grpc",
+    "rpc/lib",
+    "rpc/lib/client",
+    "rpc/lib/server",
+    "rpc/lib/types",
+    "rpc/test",
+    "state",
+    "state/txindex",
+    "state/txindex/kv",
+    "state/txindex/null",
+    "types",
+    "version"
+  ]
   revision = "a2b92c07453f66277f70d0c3979a9dac67bbecea"
   version = "v0.13.0"
 
 [[projects]]
   name = "github.com/tendermint/tmlibs"
-  packages = ["autofile","cli/flags","clist","common","db","flowrate","log","merkle","pubsub","pubsub/query"]
+  packages = [
+    "autofile",
+    "cli/flags",
+    "clist",
+    "common",
+    "db",
+    "flowrate",
+    "log",
+    "merkle",
+    "pubsub",
+    "pubsub/query"
+  ]
   revision = "bfcc0217f120d3bee6730ba0789d2eb72fc2e889"
   version = "v0.5.0"
 
@@ -376,53 +524,108 @@
   branch = "master"
   name = "github.com/xeipuuv/gojsonpointer"
   packages = ["."]
-  revision = "6fe8760cad3569743d51ddbb243b26f8456742dc"
+  revision = "4e3ac2762d5f479393488629ee9370b50873b3a6"
 
 [[projects]]
   branch = "master"
   name = "github.com/xeipuuv/gojsonreference"
   packages = ["."]
-  revision = "e02fc20de94c78484cd5ffb007f8af96be030a45"
+  revision = "bd5ef7bd5415a7ac448318e64f11a24cd21e594b"
 
 [[projects]]
   branch = "master"
   name = "github.com/xeipuuv/gojsonschema"
   packages = ["."]
-  revision = "212d8a0df7acfab8bdd190a7a69f0ab7376edcc8"
+  revision = "70e59348c29403c606624cd201e79769d6657db8"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/crypto"
-  packages = ["cast5","curve25519","nacl/box","nacl/secretbox","openpgp","openpgp/armor","openpgp/elgamal","openpgp/errors","openpgp/packet","openpgp/s2k","pbkdf2","poly1305","ripemd160","salsa20/salsa","ssh/terminal"]
-  revision = "94eea52f7b742c7cbe0b03b22f0c4c8631ece122"
+  packages = [
+    "cast5",
+    "curve25519",
+    "nacl/box",
+    "nacl/secretbox",
+    "openpgp",
+    "openpgp/armor",
+    "openpgp/elgamal",
+    "openpgp/errors",
+    "openpgp/packet",
+    "openpgp/s2k",
+    "pbkdf2",
+    "poly1305",
+    "ripemd160",
+    "salsa20/salsa",
+    "ssh/terminal"
+  ]
+  revision = "1875d0a70c90e57f11972aefd42276df65e895b9"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/net"
-  packages = ["context","context/ctxhttp","http2","http2/hpack","idna","internal/timeseries","lex/httplex","proxy","trace"]
-  revision = "d866cfc389cec985d6fda2859936a575a55a3ab6"
+  packages = [
+    "context",
+    "context/ctxhttp",
+    "http2",
+    "http2/hpack",
+    "idna",
+    "internal/timeseries",
+    "lex/httplex",
+    "proxy",
+    "trace"
+  ]
+  revision = "0ed95abb35c445290478a5348a7b38bb154135fd"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/oauth2"
-  packages = [".","internal"]
-  revision = "e585185218a1268736da499ab73c9a930e94a2a3"
+  packages = [
+    ".",
+    "internal"
+  ]
+  revision = "a032972e28060ca4f5644acffae3dfc268cc09db"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/sys"
-  packages = ["unix","windows"]
-  revision = "53aa286056ef226755cd898109dbcdaba8ac0b81"
+  packages = [
+    "unix",
+    "windows"
+  ]
+  revision = "3dbebcf8efb6a5011a60c2b4591c1022a759af8a"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/text"
-  packages = ["collate","collate/build","internal/colltab","internal/gen","internal/tag","internal/triegen","internal/ucd","language","secure/bidirule","transform","unicode/bidi","unicode/cldr","unicode/norm","unicode/rangetable"]
-  revision = "3b24cac7bc3a458991ab409aa2a339ac9e0d60d6"
+  packages = [
+    "collate",
+    "collate/build",
+    "internal/colltab",
+    "internal/gen",
+    "internal/tag",
+    "internal/triegen",
+    "internal/ucd",
+    "language",
+    "secure/bidirule",
+    "transform",
+    "unicode/bidi",
+    "unicode/cldr",
+    "unicode/norm",
+    "unicode/rangetable"
+  ]
+  revision = "e19ae1496984b1c655b8044a65c0300a3c878dd3"
 
 [[projects]]
   name = "google.golang.org/appengine"
-  packages = ["internal","internal/base","internal/datastore","internal/log","internal/remote_api","internal/urlfetch","urlfetch"]
+  packages = [
+    "internal",
+    "internal/base",
+    "internal/datastore",
+    "internal/log",
+    "internal/remote_api",
+    "internal/urlfetch",
+    "urlfetch"
+  ]
   revision = "150dc57a1b433e64154302bdc40b6bb8aefa313a"
   version = "v1.0.0"
 
@@ -430,13 +633,36 @@
   branch = "master"
   name = "google.golang.org/genproto"
   packages = ["googleapis/rpc/status"]
-  revision = "73cb5d0be5af113b42057925bd6c93e3cd9f60fd"
+  revision = "4eb30f4778eed4c258ba66527a0d4f9ec8a36c45"
 
 [[projects]]
   name = "google.golang.org/grpc"
-  packages = [".","balancer","balancer/roundrobin","codes","connectivity","credentials","encoding","grpclb/grpc_lb_v1/messages","grpclog","internal","keepalive","metadata","naming","peer","resolver","resolver/dns","resolver/manual","resolver/passthrough","stats","status","tap","transport"]
-  revision = "be077907e29fdb945d351e4284eb5361e7f8924e"
-  version = "v1.8.1"
+  packages = [
+    ".",
+    "balancer",
+    "balancer/base",
+    "balancer/roundrobin",
+    "codes",
+    "connectivity",
+    "credentials",
+    "encoding",
+    "grpclb/grpc_lb_v1/messages",
+    "grpclog",
+    "internal",
+    "keepalive",
+    "metadata",
+    "naming",
+    "peer",
+    "resolver",
+    "resolver/dns",
+    "resolver/passthrough",
+    "stats",
+    "status",
+    "tap",
+    "transport"
+  ]
+  revision = "6b51017f791ae1cfbec89c52efdf444b13b550ef"
+  version = "v1.9.2"
 
 [[projects]]
   name = "gopkg.in/dancannon/gorethink.v3"
@@ -445,20 +671,24 @@
   version = "v3.0.5"
 
 [[projects]]
-  branch = "v2.0.0"
   name = "gopkg.in/fatih/pool.v2"
   packages = ["."]
   revision = "010e0b745d12eaf8426c95f9c3924d81dd0b668f"
+  version = "v2.0.0"
 
 [[projects]]
   name = "gopkg.in/go-playground/validator.v9"
   packages = ["."]
-  revision = "61caf9d3038e1af346dbf5c2e16f6678e1548364"
-  version = "v9.9.0"
+  revision = "48a433ba4bcadc5be9aa16d4bdcb383d3f57a741"
+  version = "v9.9.3"
 
 [[projects]]
   name = "gopkg.in/gorethink/gorethink.v3"
-  packages = ["encoding","ql2","types"]
+  packages = [
+    "encoding",
+    "ql2",
+    "types"
+  ]
   revision = "7f5bdfd858bb064d80559b2a32b86669c5de5d3b"
   version = "v3.0.5"
 
@@ -466,11 +696,11 @@
   branch = "v2"
   name = "gopkg.in/yaml.v2"
   packages = ["."]
-  revision = "287cf08546ab5e7e37d55a84f7ed3fd1db036de5"
+  revision = "d670f9405373e636a5a2765eea47fac0c9bc91a4"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "cc1155e2ec87d1e9430cbc3a3f67c176d1d2a5e92e66deddae1b7e6e81ae31a7"
+  inputs-digest = "e0fba10ae59e597d21c961ee3bb0c9579678851f9761e933a9526994cfb71f84"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -39,10 +39,6 @@
   version = "0.8.0"
 
 [[constraint]]
-  branch = "master"
-  name = "github.com/tendermint/merkleeyes"
-
-[[constraint]]
   name = "github.com/tendermint/go-wire"
   version = "0.7.2"
 
@@ -76,6 +72,10 @@
   
 [[constraint]]
   name = "github.com/google/go-querystring"
+  branch="master"
+
+[[constraint]]
+  name = "github.com/jmespath/go-jmespath"
   branch="master"
 
 [[override]] 

--- a/cs/cs.go
+++ b/cs/cs.go
@@ -17,7 +17,7 @@ package cs
 
 import (
 	"crypto/sha256"
-	"encoding/hex"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"math"
@@ -223,7 +223,7 @@ func (l *Link) GetProcess() string {
 }
 
 // Validate checks for errors in a link.
-// It only validates the format of signatures, it does not verify their correctness
+// It only validates the format of signatures, it does not verify their correctness.
 func (l *Link) Validate(getSegment GetSegmentFunc) error {
 	if process, ok := l.Meta["process"].(string); !ok || process == "" {
 		return errors.New("link.meta.process should be a non empty string")
@@ -313,10 +313,10 @@ func (l *Link) validateSignaturesFormat() error {
 		for _, sig := range l.Signatures {
 			if sig.Type == "" {
 				return errors.New("signature.Type cannot be empty")
-			} else if _, err := hex.DecodeString(sig.PublicKey); err != nil || sig.PublicKey == "" {
-				return errors.Errorf("signature.PublicKey [%s] has to be an hex-encoded string", sig.PublicKey)
-			} else if _, err := hex.DecodeString(sig.Signature); err != nil || sig.Signature == "" {
-				return errors.Errorf("signature.Signature [%s] has to be an hex-encoded string", sig.Signature)
+			} else if _, err := base64.StdEncoding.DecodeString(sig.PublicKey); err != nil || sig.PublicKey == "" {
+				return errors.Errorf("signature.PublicKey [%s] has to be a base64-encoded string", sig.PublicKey)
+			} else if _, err := base64.StdEncoding.DecodeString(sig.Signature); err != nil || sig.Signature == "" {
+				return errors.Errorf("signature.Signature [%s] has to be a base64-encoded string", sig.Signature)
 			} else if _, err := jmespath.Compile(sig.Payload); err != nil {
 				return errors.Errorf("signature.Payload [%s] has to be a JMESPATH expression, got: %s", sig.Payload, err.Error())
 			}

--- a/cs/cs.go
+++ b/cs/cs.go
@@ -17,6 +17,7 @@ package cs
 
 import (
 	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"math"
@@ -28,6 +29,7 @@ import (
 	"github.com/stratumn/sdk/types"
 
 	cj "github.com/gibson042/canonicaljson-go"
+	jmespath "github.com/jmespath/go-jmespath"
 )
 
 // Segment contains a link and meta data about the link.
@@ -125,8 +127,9 @@ func (s *SegmentMeta) FindEvidences(backend string) (res Evidences) {
 
 // Link contains a state and meta data about the state.
 type Link struct {
-	State map[string]interface{} `json:"state"`
-	Meta  map[string]interface{} `json:"meta"`
+	State      map[string]interface{} `json:"state"`
+	Meta       map[string]interface{} `json:"meta"`
+	Signatures []*Signature           `json:"signatures"`
 }
 
 // Hash hashes the link
@@ -220,6 +223,7 @@ func (l *Link) GetProcess() string {
 }
 
 // Validate checks for errors in a link.
+// It only validates the format of signatures, it does not verify their correctness
 func (l *Link) Validate(getSegment GetSegmentFunc) error {
 	if process, ok := l.Meta["process"].(string); !ok || process == "" {
 		return errors.New("link.meta.process should be a non empty string")
@@ -252,6 +256,10 @@ func (l *Link) Validate(getSegment GetSegmentFunc) error {
 	}
 
 	if _, err := l.Hash(); err != nil {
+		return err
+	}
+
+	if err := l.validateSignaturesFormat(); err != nil {
 		return err
 	}
 
@@ -294,6 +302,23 @@ func (l *Link) validateReferences(getSegment GetSegmentFunc) error {
 					}
 				}
 				// Segment from another process is not retrieved because it could be in another store
+			}
+		}
+	}
+	return nil
+}
+
+func (l *Link) validateSignaturesFormat() error {
+	if l.Signatures != nil {
+		for _, sig := range l.Signatures {
+			if sig.Type == "" {
+				return errors.New("signature.Type cannot be empty")
+			} else if _, err := hex.DecodeString(sig.PublicKey); err != nil || sig.PublicKey == "" {
+				return errors.Errorf("signature.PublicKey [%s] has to be an hex-encoded string", sig.PublicKey)
+			} else if _, err := hex.DecodeString(sig.Signature); err != nil || sig.Signature == "" {
+				return errors.Errorf("signature.Signature [%s] has to be an hex-encoded string", sig.Signature)
+			} else if _, err := jmespath.Compile(sig.Payload); err != nil {
+				return errors.Errorf("signature.Payload [%s] has to be a JMESPATH expression, got: %s", sig.Payload, err.Error())
 			}
 		}
 	}

--- a/cs/cs_test.go
+++ b/cs/cs_test.go
@@ -254,6 +254,12 @@ func TestLinkValidate_refGoodNilLink(t *testing.T) {
 	}, "link.meta.refs[0] segment is nil")
 }
 
+func TestLinkValidate_validSignature(t *testing.T) {
+	l := cstesting.SignLink(cstesting.RandomLink())
+	err := l.Validate(nil)
+	assert.NoError(t, err, "l.Validate()")
+}
+
 func TestLinkValidate_emptySignatureType(t *testing.T) {
 	l := cstesting.RandomLink()
 	l.Signatures = append(l.Signatures, &cs.Signature{
@@ -266,19 +272,19 @@ func TestLinkValidate_wrongPublicKeyFormat(t *testing.T) {
 	l := cstesting.RandomLink()
 	l.Signatures = append(l.Signatures, &cs.Signature{
 		Type:      "ok",
-		PublicKey: "test",
+		PublicKey: "*test*",
 	})
-	testLinkValidateError(t, l, nil, "signature.PublicKey [test] has to be an hex-encoded string")
+	testLinkValidateError(t, l, nil, "signature.PublicKey [*test*] has to be a base64-encoded string")
 }
 
 func TestLinkValidate_wrongSignatureFormat(t *testing.T) {
 	l := cstesting.RandomLink()
 	l.Signatures = append(l.Signatures, &cs.Signature{
 		Type:      "ok",
-		PublicKey: "deadbeef",
-		Signature: "test",
+		PublicKey: "AeZ4",
+		Signature: "*test*",
 	})
-	testLinkValidateError(t, l, nil, "signature.Signature [test] has to be an hex-encoded string")
+	testLinkValidateError(t, l, nil, "signature.Signature [*test*] has to be a base64-encoded string")
 }
 
 func TestLinkValidate_wrongPaylodExpression(t *testing.T) {

--- a/cs/cs_test.go
+++ b/cs/cs_test.go
@@ -254,6 +254,44 @@ func TestLinkValidate_refGoodNilLink(t *testing.T) {
 	}, "link.meta.refs[0] segment is nil")
 }
 
+func TestLinkValidate_emptySignatureType(t *testing.T) {
+	l := cstesting.RandomLink()
+	l.Signatures = append(l.Signatures, &cs.Signature{
+		Type: "",
+	})
+	testLinkValidateError(t, l, nil, "signature.Type cannot be empty")
+}
+
+func TestLinkValidate_wrongPublicKeyFormat(t *testing.T) {
+	l := cstesting.RandomLink()
+	l.Signatures = append(l.Signatures, &cs.Signature{
+		Type:      "ok",
+		PublicKey: "test",
+	})
+	testLinkValidateError(t, l, nil, "signature.PublicKey [test] has to be an hex-encoded string")
+}
+
+func TestLinkValidate_wrongSignatureFormat(t *testing.T) {
+	l := cstesting.RandomLink()
+	l.Signatures = append(l.Signatures, &cs.Signature{
+		Type:      "ok",
+		PublicKey: "deadbeef",
+		Signature: "test",
+	})
+	testLinkValidateError(t, l, nil, "signature.Signature [test] has to be an hex-encoded string")
+}
+
+func TestLinkValidate_wrongPaylodExpression(t *testing.T) {
+	l := cstesting.RandomLink()
+	l.Signatures = append(l.Signatures, &cs.Signature{
+		Type:      "ok",
+		PublicKey: "deadbeef",
+		Signature: "deadbeef",
+		Payload:   "",
+	})
+	testLinkValidateError(t, l, nil, "signature.Payload [] has to be a JMESPATH expression, got: SyntaxError: Incomplete expression")
+}
+
 func TestSegmentSliceSort_priority(t *testing.T) {
 	slice := cs.SegmentSlice{
 		&cs.Segment{Link: cs.Link{Meta: map[string]interface{}{"priority": 2.3}}},

--- a/cs/cstesting/cstesting.go
+++ b/cs/cstesting/cstesting.go
@@ -16,8 +16,15 @@
 package cstesting
 
 import (
+	"crypto"
+	crand "crypto/rand"
+	"encoding/base64"
 	"encoding/json"
 	"math/rand"
+
+	cj "github.com/gibson042/canonicaljson-go"
+	jmespath "github.com/jmespath/go-jmespath"
+	"golang.org/x/crypto/ed25519"
 
 	"github.com/stratumn/sdk/cs"
 	"github.com/stratumn/sdk/testutil"
@@ -113,6 +120,24 @@ func RandomTags() []interface{} {
 		tags = append(tags, testutil.RandomString(12))
 	}
 	return tags
+}
+
+// SignLink adds a signature to a link.
+// The ed25519 signature algorithm is used.
+func SignLink(l *cs.Link) *cs.Link {
+	pub, priv, _ := ed25519.GenerateKey(crand.Reader)
+	payloadPath := "[state, meta]"
+	payload, _ := jmespath.Search(payloadPath, l)
+	payloadBytes, _ := cj.Marshal(payload)
+	sigBytes, _ := priv.Sign(crand.Reader, payloadBytes, crypto.Hash(0))
+	sig := cs.Signature{
+		Type:      "ed25519",
+		PublicKey: base64.StdEncoding.EncodeToString(pub),
+		Signature: base64.StdEncoding.EncodeToString(sigBytes),
+		Payload:   payloadPath,
+	}
+	l.Signatures = append(l.Signatures, &sig)
+	return l
 }
 
 // Clone clones a link.

--- a/cs/cstesting/cstesting.go
+++ b/cs/cstesting/cstesting.go
@@ -44,7 +44,8 @@ func CreateLink(process, mapID, prevLinkHash string, tags []interface{}, priorit
 		State: map[string]interface{}{
 			"random": testutil.RandomString(12),
 		},
-		Meta: linkMeta,
+		Meta:       linkMeta,
+		Signatures: cs.Signatures{},
 	}
 
 	return link

--- a/cs/signature.go
+++ b/cs/signature.go
@@ -20,14 +20,14 @@ type Signature struct {
 	// Type of the signature (eg: "EdDSA")
 	Type string `json:"type"`
 
-	// PublicKey is the hex encoded public key that signed the payload
+	// PublicKey is the base64 encoded public key that signed the payload
 	PublicKey string `json:"publicKey"`
 
-	// Signature is the hex encoded string containg the signature bytes
+	// Signature is the base64 encoded string containg the signature bytes
 	Signature string `json:"signature"`
 
-	// Paylaod describes what has been signed, It is expressed using the JMESPATH query language.
-	Payload string `json:"paylaod"`
+	// Payload describes what has been signed, It is expressed using the JMESPATH query language.
+	Payload string `json:"payload"`
 }
 
 // Signatures is a slice of Signature

--- a/cs/signature.go
+++ b/cs/signature.go
@@ -1,0 +1,44 @@
+// Copyright 2017 Stratumn SAS. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package cs defines types to work with Chainscripts.
+package cs
+
+// Signature contains a user-provided signature of a certain part of the link.
+type Signature struct {
+	// Type of the signature (eg: "EdDSA")
+	Type string `json:"type"`
+
+	// PublicKey is the hex encoded public key that signed the payload
+	PublicKey string `json:"publicKey"`
+
+	// Signature is the hex encoded string containg the signature bytes
+	Signature string `json:"signature"`
+
+	// Paylaod describes what has been signed, It is expressed using the JMESPATH query language.
+	Payload string `json:"paylaod"`
+}
+
+// Signatures is a slice of Signature
+type Signatures []*Signature
+
+// Get returns the signature matching the provided public key
+func (s *Signatures) Get(publicKey string) *Signature {
+	for _, sig := range *s {
+		if sig.PublicKey == publicKey {
+			return sig
+		}
+	}
+	return nil
+}

--- a/cs/signature_test.go
+++ b/cs/signature_test.go
@@ -1,0 +1,49 @@
+// Copyright 2017 Stratumn SAS. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cs_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/stratumn/sdk/cs"
+)
+
+func TestGetSignatures(t *testing.T) {
+	signatures := cs.Signatures{
+		&cs.Signature{
+			PublicKey: "one",
+		},
+		&cs.Signature{
+			PublicKey: "two",
+		},
+	}
+	got := signatures.Get("one")
+	assert.EqualValues(t, signatures[0], got, "signatures.Get()")
+}
+
+func TestGetSignatures_NotFound(t *testing.T) {
+	signatures := cs.Signatures{
+		&cs.Signature{
+			PublicKey: "one",
+		},
+		&cs.Signature{
+			PublicKey: "two",
+		},
+	}
+	got := signatures.Get("wrong")
+	assert.Nil(t, got, "s.Get(()")
+}

--- a/tmpop/state.go
+++ b/tmpop/state.go
@@ -73,6 +73,7 @@ func (s *State) Deliver(link *cs.Link) *ABCIError {
 	return res
 }
 
+// checkLinkAndAddToBatch validates the link's format and runs the validations (signatures, schema)
 func (s *State) checkLinkAndAddToBatch(link *cs.Link, batch store.Batch) *ABCIError {
 	err := link.Validate(batch.GetSegment)
 	if err != nil {

--- a/validator/baseconfig.go
+++ b/validator/baseconfig.go
@@ -1,0 +1,73 @@
+// Copyright 2017 Stratumn SAS. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validator
+
+import (
+	log "github.com/sirupsen/logrus"
+
+	"github.com/pkg/errors"
+	"github.com/stratumn/sdk/cs"
+)
+
+var (
+	// ErrMissingProcess is returned when the process name is missing for schema validation.
+	ErrMissingProcess = errors.New("schema validation requires a process")
+
+	// ErrMissingLinkType is returned when the link type is missing for schema validation.
+	ErrMissingLinkType = errors.New("schema validation requires a link type")
+)
+
+type validatorBaseConfig struct {
+	Process  string
+	LinkType string
+}
+
+func newValidatorBaseConfig(process, linkType string) (*validatorBaseConfig, error) {
+	if len(process) == 0 {
+		return nil, ErrMissingProcess
+	}
+
+	if len(linkType) == 0 {
+		return nil, ErrMissingLinkType
+	}
+	return &validatorBaseConfig{Process: process, LinkType: linkType}, nil
+}
+
+// shouldValidate returns true if the link matches the validator's process
+// and type. Otherwise the link is considered valid because this validator
+// doesn't apply to it.
+func (bv *validatorBaseConfig) shouldValidate(link *cs.Link) bool {
+	linkProcess, ok := link.Meta["process"].(string)
+	if !ok {
+		log.Debug("No process found in link %v", link)
+		return false
+	}
+
+	if linkProcess != bv.Process {
+		return false
+	}
+
+	linkAction, ok := link.Meta["action"].(string)
+	if !ok {
+		log.Debug("No action found in link %v", link)
+		return false
+	}
+
+	if linkAction != bv.LinkType {
+		return false
+	}
+
+	return true
+}

--- a/validator/baseconfig_test.go
+++ b/validator/baseconfig_test.go
@@ -1,0 +1,76 @@
+// Copyright 2017 Stratumn SAS. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validator
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBaseConfig(t *testing.T) {
+	process := "p1"
+	linkType := "sell"
+
+	type testCaseCfg struct {
+		name          string
+		process       string
+		linkType      string
+		schema        []byte
+		valid         bool
+		expectedError error
+	}
+
+	testCases := []testCaseCfg{{
+		name:          "missing-process",
+		process:       "",
+		linkType:      linkType,
+		valid:         false,
+		expectedError: ErrMissingProcess,
+	}, {
+		name:          "missing-link-type",
+		process:       process,
+		linkType:      "",
+		valid:         false,
+		expectedError: ErrMissingLinkType,
+	}, {
+		name:     "valid-config",
+		process:  process,
+		linkType: linkType,
+		valid:    true,
+	},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg, err := newValidatorBaseConfig(
+				tt.process,
+				tt.linkType,
+			)
+
+			if tt.valid {
+				assert.NotNil(t, cfg)
+				assert.NoError(t, err)
+			} else {
+				assert.Nil(t, cfg)
+				assert.Error(t, err)
+				if tt.expectedError != nil {
+					assert.EqualError(t, err, tt.expectedError.Error())
+				}
+
+			}
+		})
+	}
+}

--- a/validator/configloader.go
+++ b/validator/configloader.go
@@ -61,7 +61,8 @@ func loadValidatorsConfig(data []byte) (*MultiValidatorConfig, error) {
 		for _, val := range jsonSchemaData {
 			if val.Type == "" {
 				return nil, ErrMissingLinkType
-			} else if val.Signatures == nil && val.Schema == nil {
+			}
+			if val.Signatures == nil && val.Schema == nil {
 				return nil, ErrInvalidValidator
 			}
 

--- a/validator/configloader.go
+++ b/validator/configloader.go
@@ -23,8 +23,8 @@ import (
 )
 
 var (
-	// ErrMissingSchema is returned when the schema is missing for schema validation.
-	ErrMissingSchema = errors.New("schema validation requires a schema")
+	// ErrInvalidValidator is returned when the schema and the signatures are both missing in a validator.
+	ErrInvalidValidator = errors.New("a validator requires a JSON schema or a signature criteria to be valid")
 )
 
 // LoadConfig loads the validators configuration from a json file.
@@ -40,46 +40,50 @@ func LoadConfig(path string) (*MultiValidatorConfig, error) {
 		return nil, errors.WithStack(err)
 	}
 
-	schemaValidators, err := loadSchemaValidatorsConfig(data)
-	if err != nil {
-		return nil, err
-	}
-
-	return &MultiValidatorConfig{SchemaConfigs: schemaValidators}, nil
+	return loadValidatorsConfig(data)
 }
 
 type jsonSchemaData []struct {
-	Type   string           `json:"type"`
-	Schema *json.RawMessage `json:"schema"`
+	Type       string           `json:"type"`
+	Signatures *bool            `json:"signatures"`
+	Schema     *json.RawMessage `json:"schema"`
 }
 
-func loadSchemaValidatorsConfig(data []byte) ([]*schemaValidatorConfig, error) {
+func loadValidatorsConfig(data []byte) (*MultiValidatorConfig, error) {
 	var jsonStruct map[string]jsonSchemaData
 	err := json.Unmarshal(data, &jsonStruct)
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
 
-	var schemaValidators []*schemaValidatorConfig
+	var validatorConfig MultiValidatorConfig
 	for process, jsonSchemaData := range jsonStruct {
 		for _, val := range jsonSchemaData {
-			if val.Schema == nil {
-				return nil, ErrMissingSchema
-			}
-
 			if val.Type == "" {
 				return nil, ErrMissingLinkType
+			} else if val.Signatures == nil && val.Schema == nil {
+				return nil, ErrInvalidValidator
 			}
 
-			schemaData, _ := val.Schema.MarshalJSON()
-			cfg, err := newSchemaValidatorConfig(process, val.Type, schemaData)
-			if err != nil {
-				return nil, err
+			if val.Signatures != nil && *val.Signatures {
+				cfg, err := newSignatureValidatorConfig(process, val.Type)
+				if err != nil {
+					return nil, err
+				}
+				validatorConfig.SignatureConfigs = append(validatorConfig.SignatureConfigs, cfg)
 			}
 
-			schemaValidators = append(schemaValidators, cfg)
+			if val.Schema != nil {
+				schemaData, _ := val.Schema.MarshalJSON()
+				cfg, err := newSchemaValidatorConfig(process, val.Type, schemaData)
+				if err != nil {
+					return nil, err
+				}
+				validatorConfig.SchemaConfigs = append(validatorConfig.SchemaConfigs, cfg)
+			}
+
 		}
 	}
 
-	return schemaValidators, nil
+	return &validatorConfig, nil
 }

--- a/validator/configloader_test.go
+++ b/validator/configloader_test.go
@@ -28,6 +28,7 @@ const validJSONConfig = `
   "auction": [
     {
       "type": "init",
+      "signatures": true,
       "schema": {
         "type": "object",
         "properties": {
@@ -72,6 +73,7 @@ const validJSONConfig = `
   "chat": [
     {
       "type": "message",
+      "signatures": false,
       "schema": {
         "type": "object",
         "properties": {
@@ -87,6 +89,10 @@ const validJSONConfig = `
           "content"
         ]   
       }
+    },
+    {
+	"type": "init",
+	"signatures": true    
     }
   ]
 }
@@ -107,6 +113,7 @@ func TestLoadConfig_Success(t *testing.T) {
 	assert.NotNil(t, cfg)
 
 	assert.Len(t, cfg.SchemaConfigs, 3)
+	assert.Len(t, cfg.SignatureConfigs, 2)
 }
 
 const invalidJSONConfig = `
@@ -144,5 +151,5 @@ func TestLoadConfig_Error(t *testing.T) {
 	cfg, err := LoadConfig(tmpfile.Name())
 
 	assert.Nil(t, cfg)
-	assert.EqualError(t, err, ErrMissingSchema.Error())
+	assert.EqualError(t, err, ErrInvalidValidator.Error())
 }

--- a/validator/multivalidator.go
+++ b/validator/multivalidator.go
@@ -27,7 +27,8 @@ import (
 // MultiValidatorConfig sets the behavior of the validator.
 // Its hash can be used to know which validations were applied to a block.
 type MultiValidatorConfig struct {
-	SchemaConfigs []*schemaValidatorConfig
+	SchemaConfigs    []*schemaValidatorConfig
+	SignatureConfigs []*signatureValidatorConfig
 }
 
 type multiValidator struct {
@@ -46,6 +47,9 @@ func NewMultiValidator(config *MultiValidatorConfig) Validator {
 	var v []validator
 	for _, schemaCfg := range config.SchemaConfigs {
 		v = append(v, newSchemaValidator(schemaCfg))
+	}
+	for _, signatureCfg := range config.SignatureConfigs {
+		v = append(v, newSignatureValidator(signatureCfg))
 	}
 
 	return &multiValidator{

--- a/validator/multivalidator_test.go
+++ b/validator/multivalidator_test.go
@@ -37,50 +37,78 @@ func TestMultiValidator_New(t *testing.T) {
 }
 
 func TestMultiValidator_Hash(t *testing.T) {
-	mv1 := NewMultiValidator(&MultiValidatorConfig{
-		SchemaConfigs: []*schemaValidatorConfig{
-			&schemaValidatorConfig{
-				validatorBaseConfig: validatorBaseConfig{Process: "p"},
-			},
-		},
-		SignatureConfigs: []*signatureValidatorConfig{
-			&signatureValidatorConfig{},
-		},
+	baseConfig1 := &validatorBaseConfig{Process: "p"}
+	baseConfig2 := &validatorBaseConfig{Process: "p2"}
+
+	t.Run("With schema validator", func(t *testing.T) {
+		mv1 := NewMultiValidator(&MultiValidatorConfig{
+			SchemaConfigs: []*schemaValidatorConfig{
+				&schemaValidatorConfig{
+					validatorBaseConfig: baseConfig1,
+				}},
+		})
+
+		h1, err := mv1.Hash()
+		assert.NoError(t, err)
+		assert.NotNil(t, h1)
+
+		mv2 := NewMultiValidator(&MultiValidatorConfig{
+			SchemaConfigs: []*schemaValidatorConfig{
+				&schemaValidatorConfig{
+					validatorBaseConfig: baseConfig1,
+				}},
+		})
+
+		h2, err := mv2.Hash()
+		assert.NoError(t, err)
+		assert.EqualValues(t, h1, h2)
+
+		mv3 := NewMultiValidator(&MultiValidatorConfig{
+			SchemaConfigs: []*schemaValidatorConfig{
+				&schemaValidatorConfig{
+					validatorBaseConfig: baseConfig2,
+				}},
+		})
+
+		h3, err := mv3.Hash()
+		assert.NoError(t, err)
+		assert.False(t, h1.Equals(h3))
 	})
 
-	h1, err := mv1.Hash()
-	assert.NoError(t, err)
-	assert.NotNil(t, h1)
+	t.Run("With signature validator", func(t *testing.T) {
+		mv1 := NewMultiValidator(&MultiValidatorConfig{
+			SignatureConfigs: []*signatureValidatorConfig{
+				&signatureValidatorConfig{
+					validatorBaseConfig: baseConfig1,
+				}},
+		})
 
-	mv2 := NewMultiValidator(&MultiValidatorConfig{
-		SchemaConfigs: []*schemaValidatorConfig{
-			&schemaValidatorConfig{
-				validatorBaseConfig: validatorBaseConfig{Process: "p"},
-			},
-		},
-		SignatureConfigs: []*signatureValidatorConfig{
-			&signatureValidatorConfig{},
-		},
+		h1, err := mv1.Hash()
+		assert.NoError(t, err)
+		assert.NotNil(t, h1)
+
+		mv2 := NewMultiValidator(&MultiValidatorConfig{
+			SignatureConfigs: []*signatureValidatorConfig{
+				&signatureValidatorConfig{
+					validatorBaseConfig: baseConfig1,
+				}},
+		})
+
+		h2, err := mv2.Hash()
+		assert.NoError(t, err)
+		assert.EqualValues(t, h1, h2)
+
+		mv3 := NewMultiValidator(&MultiValidatorConfig{
+			SignatureConfigs: []*signatureValidatorConfig{
+				&signatureValidatorConfig{
+					validatorBaseConfig: baseConfig2,
+				}},
+		})
+
+		h3, err := mv3.Hash()
+		assert.NoError(t, err)
+		assert.False(t, h1.Equals(h3))
 	})
-
-	h2, err := mv2.Hash()
-	assert.NoError(t, err)
-	assert.EqualValues(t, h1, h2)
-
-	mv3 := NewMultiValidator(&MultiValidatorConfig{
-		SchemaConfigs: []*schemaValidatorConfig{
-			&schemaValidatorConfig{
-				validatorBaseConfig: validatorBaseConfig{Process: "p2"},
-			},
-		},
-		SignatureConfigs: []*signatureValidatorConfig{
-			&signatureValidatorConfig{},
-		},
-	})
-
-	h3, err := mv3.Hash()
-	assert.NoError(t, err)
-	assert.False(t, h1.Equals(h3))
 }
 
 const testMessageSchema = `

--- a/validator/schema.go
+++ b/validator/schema.go
@@ -22,34 +22,21 @@ import (
 	"github.com/stratumn/sdk/cs"
 	"github.com/stratumn/sdk/store"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/xeipuuv/gojsonschema"
-)
-
-var (
-	// ErrMissingProcess is returned when the process name is missing for schema validation.
-	ErrMissingProcess = errors.New("schema validation requires a process")
-
-	// ErrMissingLinkType is returned when the link type is missing for schema validation.
-	ErrMissingLinkType = errors.New("schema validation requires a link type")
 )
 
 // schemaValidatorConfig contains everything a schemaValidator needs to
 // validate links.
 type schemaValidatorConfig struct {
-	Process  string
-	LinkType string
-	Schema   *gojsonschema.Schema
+	validatorBaseConfig
+	Schema *gojsonschema.Schema
 }
 
 // newSchemaValidatorConfig creates a schemaValidatorConfig for a given process and type.
 func newSchemaValidatorConfig(process, linkType string, schemaData []byte) (*schemaValidatorConfig, error) {
-	if len(process) == 0 {
-		return nil, ErrMissingProcess
-	}
-
-	if len(linkType) == 0 {
-		return nil, ErrMissingLinkType
+	baseConfig, err := newValidatorBaseConfig(process, linkType)
+	if err != nil {
+		return nil, errors.WithStack(err)
 	}
 
 	schema, err := gojsonschema.NewSchema(gojsonschema.NewBytesLoader(schemaData))
@@ -58,9 +45,8 @@ func newSchemaValidatorConfig(process, linkType string, schemaData []byte) (*sch
 	}
 
 	return &schemaValidatorConfig{
-		Process:  process,
-		LinkType: linkType,
-		Schema:   schema,
+		validatorBaseConfig: *baseConfig,
+		Schema:              schema,
 	}, nil
 }
 
@@ -73,30 +59,11 @@ func newSchemaValidator(config *schemaValidatorConfig) validator {
 	return &schemaValidator{config: config}
 }
 
-// shouldValidate returns true if the link matches the validator's process
-// and type. Otherwise the link is considered valid because this validator
-// doesn't apply to it.
+// check that the process and link type match the validators' attributes
 func (sv schemaValidator) shouldValidate(link *cs.Link) bool {
-	linkProcess, ok := link.Meta["process"].(string)
-	if !ok {
-		log.Debug("No process found in link %v", link)
+	if !sv.config.shouldValidate(link) {
 		return false
 	}
-
-	if linkProcess != sv.config.Process {
-		return false
-	}
-
-	linkAction, ok := link.Meta["action"].(string)
-	if !ok {
-		log.Debug("No action found in link %v", link)
-		return false
-	}
-
-	if linkAction != sv.config.LinkType {
-		return false
-	}
-
 	return true
 }
 

--- a/validator/schema.go
+++ b/validator/schema.go
@@ -28,7 +28,7 @@ import (
 // schemaValidatorConfig contains everything a schemaValidator needs to
 // validate links.
 type schemaValidatorConfig struct {
-	validatorBaseConfig
+	*validatorBaseConfig
 	Schema *gojsonschema.Schema
 }
 
@@ -45,7 +45,7 @@ func newSchemaValidatorConfig(process, linkType string, schemaData []byte) (*sch
 	}
 
 	return &schemaValidatorConfig{
-		validatorBaseConfig: *baseConfig,
+		validatorBaseConfig: baseConfig,
 		Schema:              schema,
 	}, nil
 }
@@ -59,17 +59,9 @@ func newSchemaValidator(config *schemaValidatorConfig) validator {
 	return &schemaValidator{config: config}
 }
 
-// check that the process and link type match the validators' attributes
-func (sv schemaValidator) shouldValidate(link *cs.Link) bool {
-	if !sv.config.shouldValidate(link) {
-		return false
-	}
-	return true
-}
-
 // Validate validates the schema of a link's state.
 func (sv schemaValidator) Validate(_ store.SegmentReader, link *cs.Link) error {
-	if !sv.shouldValidate(link) {
+	if !sv.config.shouldValidate(link) {
 		return nil
 	}
 

--- a/validator/schema_test.go
+++ b/validator/schema_test.go
@@ -61,20 +61,6 @@ func TestSchemaValidatorConfig(t *testing.T) {
 	}
 
 	testCases := []testCase{{
-		name:          "missing-process",
-		process:       "",
-		linkType:      linkType,
-		schema:        validSchema,
-		valid:         false,
-		expectedError: ErrMissingProcess,
-	}, {
-		name:          "missing-link-type",
-		process:       process,
-		linkType:      "",
-		schema:        validSchema,
-		valid:         false,
-		expectedError: ErrMissingLinkType,
-	}, {
 		name:     "invalid-schema",
 		process:  process,
 		linkType: linkType,

--- a/validator/signature.go
+++ b/validator/signature.go
@@ -1,0 +1,77 @@
+// Copyright 2017 Stratumn SAS. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validator
+
+import (
+	"github.com/pkg/errors"
+	"github.com/stratumn/sdk/cs"
+	"github.com/stratumn/sdk/store"
+)
+
+var (
+	// ErrMissingSignature is returned when there are no signatures in the link
+	ErrMissingSignature = errors.New("signature validation requires link.signatures to contain at least one element")
+)
+
+// signatureValidatorConfig contains everything a signatureValidator needs to
+// validate links.
+type signatureValidatorConfig struct {
+	validatorBaseConfig
+}
+
+// newSignatureValidatorConfig creates a signatureValidatorConfig for a given process and type.
+func newSignatureValidatorConfig(process, linkType string) (*signatureValidatorConfig, error) {
+	baseConfig, err := newValidatorBaseConfig(process, linkType)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+
+	return &signatureValidatorConfig{*baseConfig}, nil
+}
+
+// signatureValidator validates the json signature of a link's state.
+type signatureValidator struct {
+	config *signatureValidatorConfig
+}
+
+func newSignatureValidator(config *signatureValidatorConfig) validator {
+	return &signatureValidator{config: config}
+}
+
+// check that the process and link type match the validators' attributes
+func (sv signatureValidator) shouldValidate(link *cs.Link) bool {
+	if !sv.config.shouldValidate(link) {
+		return false
+	}
+	return true
+}
+
+// Validate validates the signature of a link's state.
+func (sv signatureValidator) Validate(_ store.SegmentReader, link *cs.Link) error {
+	if !sv.shouldValidate(link) {
+		return nil
+	}
+
+	if len(link.Signatures) == 0 {
+		return ErrMissingSignature
+	}
+
+	// TODO: check that
+	// - signature type is supported
+	// - signature is correct
+	// - required signatures for this action are present/valid
+
+	return nil
+}

--- a/validator/signature.go
+++ b/validator/signature.go
@@ -28,7 +28,7 @@ var (
 // signatureValidatorConfig contains everything a signatureValidator needs to
 // validate links.
 type signatureValidatorConfig struct {
-	validatorBaseConfig
+	*validatorBaseConfig
 }
 
 // newSignatureValidatorConfig creates a signatureValidatorConfig for a given process and type.
@@ -38,7 +38,7 @@ func newSignatureValidatorConfig(process, linkType string) (*signatureValidatorC
 		return nil, errors.WithStack(err)
 	}
 
-	return &signatureValidatorConfig{*baseConfig}, nil
+	return &signatureValidatorConfig{baseConfig}, nil
 }
 
 // signatureValidator validates the json signature of a link's state.
@@ -50,17 +50,9 @@ func newSignatureValidator(config *signatureValidatorConfig) validator {
 	return &signatureValidator{config: config}
 }
 
-// check that the process and link type match the validators' attributes
-func (sv signatureValidator) shouldValidate(link *cs.Link) bool {
-	if !sv.config.shouldValidate(link) {
-		return false
-	}
-	return true
-}
-
 // Validate validates the signature of a link's state.
 func (sv signatureValidator) Validate(_ store.SegmentReader, link *cs.Link) error {
-	if !sv.shouldValidate(link) {
+	if !sv.config.shouldValidate(link) {
 		return nil
 	}
 

--- a/validator/signature_test.go
+++ b/validator/signature_test.go
@@ -1,0 +1,88 @@
+// Copyright 2017 Stratumn SAS. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validator
+
+import (
+	"testing"
+
+	"github.com/stratumn/sdk/cs"
+	"github.com/stratumn/sdk/cs/cstesting"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSignatureValidator(t *testing.T) {
+	cfg, err := newSignatureValidatorConfig("p1", "test")
+	require.NoError(t, err)
+	sv := newSignatureValidator(cfg)
+
+	createValidLink := func() *cs.Link {
+		l := cstesting.RandomLink()
+		l.Meta["process"] = "p1"
+		l.Meta["action"] = "test"
+		l.Signatures = append(l.Signatures, &cs.Signature{})
+		return l
+	}
+
+	createInvalidLink := func() *cs.Link {
+		l := createValidLink()
+		l.Signatures = nil
+		return l
+	}
+
+	type testCase struct {
+		name  string
+		link  func() *cs.Link
+		valid bool
+	}
+
+	testCases := []testCase{{
+		name:  "process-not-matched",
+		valid: true,
+		link: func() *cs.Link {
+			l := createInvalidLink()
+			l.Meta["process"] = "p2"
+			return l
+		},
+	}, {
+		name:  "type-not-matched",
+		valid: true,
+		link: func() *cs.Link {
+			l := createInvalidLink()
+			l.Meta["action"] = "buy"
+			return l
+		},
+	}, {
+		name:  "valid-link",
+		valid: true,
+		link:  createValidLink,
+	}, {
+		name:  "invalid-link",
+		valid: false,
+		link:  createInvalidLink,
+	}}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			err := sv.Validate(nil, tt.link())
+			if tt.valid {
+				assert.NoError(t, err)
+			} else {
+				assert.EqualError(t, err, ErrMissingSignature.Error())
+			}
+		})
+	}
+
+}


### PR DESCRIPTION
- link format is evolving : there is a new `Signatures` field 
```golang
type Link struct {
	State      map[string]interface{} `json:"state"`
	Meta       map[string]interface{} `json:"meta"`
	Signatures []*Signature           `json:"signatures"`
}
```

- a new boolean `signatures` can be added in in the validators : 
```json
"myprocess": [{
   "type": "init",
   "signatures": true,
   "schema": {...}
}, {
   "type": "someAction",
   "signatures": true
}]
```
If this boolean is set to true, signatures present in the link will be verified. If it's omitted, signatures won't be checked. This parameter may be used independently from the `schema` one.

NEXT PR : actual verification of signatures using the `go-jmespath` package to determine the payload and the `ed25519` signature algorithm.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stratumn/sdk/335)
<!-- Reviewable:end -->
