### PR TITLE
validator: factorize signature verification, add ECDSA & RSA

### DIFF
--- a/validator/signature/ecdsa.go
+++ b/validator/signature/ecdsa.go
@@ -1,0 +1,56 @@
+// Copyright 2017 Stratumn SAS. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package signature
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"encoding/asn1"
+	"math/big"
+
+	"github.com/pkg/errors"
+)
+
+var (
+	// ErrInvalidECDSAPublicKey is returned when the unmarshalling of an ecdsa public key failed
+	ErrInvalidECDSAPublicKey = errors.New("Could not parse ECDSA public key, wrong (X, Y) parameters")
+)
+
+// ecdsaSignature is used to encode/decode ECDSA signatures to/from ASN-1.
+// It is used the same way as in the "crypto/ecdsa" package (which does not export this type)
+type ecdsaSignature struct {
+	R, S *big.Int
+}
+
+// newECDSASignature serializes a bytes-formatted signature into a pair of bigInts
+func newECDSASignature(bytesSignature []byte) (*ecdsaSignature, error) {
+	var sig ecdsaSignature
+	if _, err := asn1.Unmarshal(bytesSignature, &sig); err != nil {
+		return nil, err
+	}
+	return &sig, nil
+}
+
+func newECDSAPublicKey(curve elliptic.Curve, key []byte) (*ecdsa.PublicKey, error) {
+	x, y := elliptic.Unmarshal(curve, key)
+	if x == nil {
+		return nil, ErrInvalidECDSAPublicKey
+	}
+	return &ecdsa.PublicKey{
+		Curve: curve,
+		X:     x,
+		Y:     y,
+	}, nil
+}

--- a/validator/signature/rsa.go
+++ b/validator/signature/rsa.go
@@ -1,0 +1,41 @@
+// Copyright 2017 Stratumn SAS. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package signature
+
+import (
+	"crypto/rsa"
+	"encoding/asn1"
+
+	"github.com/pkg/errors"
+)
+
+const (
+	// RSAKeySize is the length of the rsa key in bits
+	RSAKeySize = 2048
+)
+
+var (
+	// ErrInvalidRSAPublicKey is returned when the unmarshalling of an rsa public key failed
+	ErrInvalidRSAPublicKey = errors.New("Could not parse RSA public key, wrong (N, E) parameters")
+)
+
+func newRSAPublicKey(key []byte) (*rsa.PublicKey, error) {
+	var publicKey rsa.PublicKey
+	_, err := asn1.Unmarshal(key, &publicKey)
+	if err != nil {
+		return nil, errors.Wrap(ErrInvalidRSAPublicKey, "Error while decoding public key")
+	}
+	return &publicKey, nil
+}

--- a/validator/signature/schemes.go
+++ b/validator/signature/schemes.go
@@ -1,0 +1,111 @@
+// Copyright 2017 Stratumn SAS. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package signature
+
+import (
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rsa"
+	"crypto/sha512"
+	"strings"
+
+	"github.com/pkg/errors"
+	"golang.org/x/crypto/ed25519"
+)
+
+const (
+	// Ed25519 is the EdDSA signature scheme using SHA-512/256 and Curve25519.
+	Ed25519 = "ED25519"
+
+	// ECDSA256 is the ecdsa scheme using a P-256 ellipitc curve
+	ECDSA256 = "ECDSA256"
+
+	// RSA is the digital signature scheme as defined in PKCS#1 (RSASSA-PKCS1-v1_5)
+	RSA = "RSA"
+)
+
+var (
+	// SupportedSignatureTypes is a list of the supported signature types.
+	supportedSignatureTypes = []string{Ed25519, ECDSA256, RSA}
+
+	// ErrInvalidSignature is returned when the signature verification failed.
+	ErrInvalidSignature = errors.New("signature verification failed")
+
+	// ErrUnsupportedSignatureType is returned when the signature type is not supported.
+	ErrUnsupportedSignatureType = errors.Errorf("signature type must be one of %v", supportedSignatureTypes)
+)
+
+// MatchScheme returns the signature scheme if it is currently supported and an error otherwise
+func MatchScheme(sigType string) (string, error) {
+	for _, supportedSig := range supportedSignatureTypes {
+		if strings.EqualFold(sigType, supportedSig) {
+			return supportedSig, nil
+		}
+	}
+	return "", errors.Wrapf(ErrUnsupportedSignatureType, "Unhandled signature scheme [%s]", sigType)
+}
+
+// Verify checks that the signature scheme is supported and runs the verification for this scheme.
+// It returns an error if the verification failed and nil otherwise.
+// _______________________________________
+// Public keys must be encoded as follows:
+// - Ed25519: no encoding necessary, public key length should be 32 bytes.
+// - ECDSA256: point (X, Y) of the public key must be encoded into the form specified in section 4.3.6 of ANSI X9.62 ("Point-to-Octet-String Conversion").
+// - RSA: public key (modulus, public exponent) must be ASN-1 encoded.
+// ______________________________________
+// Signatures must be encoded as follows:
+// - Ed25519: no encoding necessary, signature length should be 64 bytes.
+// - ECDSA256: ecdsa signatures (R, S *big.Int) must be encoded to ASN-1.
+// - RSA: signatures must be computed using PKCS1-v1_5. What should be signed is the SHA512 sum of the document, not the document itself.
+func Verify(sigType string, key, signature, document []byte) error {
+	scheme, err := MatchScheme(sigType)
+	if err != nil {
+		return err
+	}
+
+	switch scheme {
+	case Ed25519:
+		publicKey := ed25519.PublicKey(key)
+		if len(publicKey) != ed25519.PublicKeySize {
+			return errors.Errorf("Ed25519 public key length must be %d, got %d", ed25519.PublicKeySize, len(publicKey))
+		}
+		if !ed25519.Verify(publicKey, document, signature) {
+			return ErrInvalidSignature
+		}
+	case ECDSA256:
+		publicKey, err := newECDSAPublicKey(elliptic.P256(), key)
+		if err != nil {
+			return err
+		}
+		ecdsaSig, err := newECDSASignature(signature)
+		if err != nil {
+			return errors.Wrap(err, "Could not parse ECDSA signature")
+		}
+		if !ecdsa.Verify(publicKey, document, ecdsaSig.R, ecdsaSig.S) {
+			return ErrInvalidSignature
+		}
+	case RSA:
+		publicKey, err := newRSAPublicKey(key)
+		if err != nil {
+			return err
+		}
+		hashedDocument := sha512.Sum512(document)
+		if err := rsa.VerifyPKCS1v15(publicKey, crypto.SHA512, hashedDocument[:], signature); err != nil {
+			return errors.Wrap(err, ErrInvalidSignature.Error())
+		}
+	}
+	return nil
+}

--- a/validator/signature/schemes_test.go
+++ b/validator/signature/schemes_test.go
@@ -1,0 +1,141 @@
+// Copyright 2017 Stratumn SAS. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package signature
+
+import (
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha512"
+	"encoding/asn1"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/crypto/ed25519"
+)
+
+func TestMatchScheme(t *testing.T) {
+
+	t.Run("Known schemes", func(t *testing.T) {
+		schemes := map[string]string{"ed25519": Ed25519, "ecdsa256": ECDSA256, "rsa": RSA}
+		for s, known := range schemes {
+			got, err := MatchScheme(s)
+			assert.NoError(t, err)
+			assert.Equal(t, known, got)
+		}
+	})
+
+	t.Run("Unknown scheme", func(t *testing.T) {
+		scheme := "test"
+		got, err := MatchScheme(scheme)
+		assert.EqualError(t, err, "Unhandled signature scheme [test]: signature type must be one of [ED25519 ECDSA256 RSA]")
+		assert.Empty(t, got)
+	})
+}
+func TestVerify(t *testing.T) {
+
+	document := []byte("test")
+
+	t.Run("Ed25519", func(t *testing.T) {
+
+		pub, priv, _ := ed25519.GenerateKey(rand.Reader)
+		sig := ed25519.Sign(priv, document)
+
+		t.Run("Valid signature", func(t *testing.T) {
+			err := Verify(Ed25519, pub, sig, document)
+			assert.NoError(t, err)
+		})
+
+		t.Run("Invalid signature", func(t *testing.T) {
+			err := Verify(Ed25519, pub, []byte("test"), document)
+			assert.EqualError(t, err, "signature verification failed")
+		})
+
+		t.Run("Bad public key length", func(t *testing.T) {
+			err := Verify(Ed25519, []byte("test"), sig, document)
+			assert.EqualError(t, err, "Ed25519 public key length must be 32, got 4")
+		})
+	})
+
+	t.Run("ECDSA256", func(t *testing.T) {
+		priv, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+		r, s, err := ecdsa.Sign(rand.Reader, priv, document)
+		require.NoError(t, err)
+
+		// priv.X and priv.Y correspond to the public key. It is encoded using elliptic.Marshal.
+		pub := elliptic.Marshal(elliptic.P256(), priv.X, priv.Y)
+
+		// sig must me ASN-1 encoded
+		sig, err := asn1.Marshal(ecdsaSignature{r, s})
+		require.NoError(t, err)
+
+		t.Run("Valid signature", func(t *testing.T) {
+			err := Verify(ECDSA256, pub, sig, document)
+			assert.NoError(t, err)
+		})
+
+		t.Run("Invalid signature", func(t *testing.T) {
+			r := big.NewInt(0)
+			s := big.NewInt(0)
+			sig, _ := asn1.Marshal(ecdsaSignature{r, s})
+			err = Verify(ECDSA256, pub, sig, document)
+			assert.EqualError(t, err, "signature verification failed")
+		})
+
+		t.Run("Bad public key format", func(t *testing.T) {
+			err := Verify(ECDSA256, []byte("test"), sig, document)
+			assert.EqualError(t, err, "Could not parse ECDSA public key, wrong (X, Y) parameters")
+		})
+
+		t.Run("Bad signature format", func(t *testing.T) {
+			err := Verify(ECDSA256, pub, []byte("test"), document)
+			assert.Error(t, err, "Ed25519 public key length must be 32, got 4")
+		})
+	})
+
+	t.Run("RSA", func(t *testing.T) {
+		priv, _ := rsa.GenerateKey(rand.Reader, RSAKeySize)
+
+		// sign the SHA512 hash of the document
+		hashed := sha512.Sum512(document)
+		sig, err := rsa.SignPKCS1v15(rand.Reader, priv, crypto.SHA512, hashed[:])
+		require.NoError(t, err)
+
+		// RSA public key must me ASN-1 encoded
+		pub, err := asn1.Marshal(priv.PublicKey)
+		require.NoError(t, err)
+
+		t.Run("Valid signature", func(t *testing.T) {
+			err := Verify(RSA, pub, sig, document)
+			assert.NoError(t, err)
+		})
+
+		t.Run("Invalid signature", func(t *testing.T) {
+			sig, err := rsa.SignPKCS1v15(rand.Reader, priv, crypto.SHA512, []byte(""))
+			err = Verify(RSA, pub, sig, document)
+			assert.EqualError(t, err, "signature verification failed: crypto/rsa: verification error")
+		})
+
+		t.Run("Bad public key format", func(t *testing.T) {
+			err := Verify(RSA, []byte("test"), sig, document)
+			assert.EqualError(t, err, "Error while decoding public key: Could not parse RSA public key, wrong (N, E) parameters")
+		})
+	})
+}

--- a/validator/signature_test.go
+++ b/validator/signature_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/stratumn/sdk/cs"
 	"github.com/stratumn/sdk/cs/cstesting"
+	"github.com/stratumn/sdk/validator/signature"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -81,7 +82,7 @@ func TestSignatureValidator(t *testing.T) {
 		{
 			name:  "unsupported-signature-type",
 			valid: false,
-			err:   ErrUnsupportedSignatureType.Error(),
+			err:   "Unhandled signature scheme [test]: " + signature.ErrUnsupportedSignatureType.Error(),
 			link: func() *cs.Link {
 				l := createValidLink()
 				l.Signatures[0].Type = "test"
@@ -109,19 +110,9 @@ func TestSignatureValidator(t *testing.T) {
 			},
 		},
 		{
-			name:  "bad-public-key-length",
-			valid: false,
-			err:   "Ed25519 public key length must be 32, got 3",
-			link: func() *cs.Link {
-				l := createValidLink()
-				l.Signatures[0].PublicKey = "test"
-				return l
-			},
-		},
-		{
 			name:  "wrong-signature",
 			valid: false,
-			err:   "signature verification failed",
+			err:   signature.ErrInvalidSignature.Error(),
 			link: func() *cs.Link {
 				l := createValidLink()
 				l.Signatures[0].Signature = "test"


### PR DESCRIPTION
I factorized signature validation so it's trace compatible.
Handled signature schemes are now ed25519, ecdsa256 and RSA.

I'll update trace-api once it is merged with master.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stratumn/sdk/337)
<!-- Reviewable:end -->
