### PR TITLE
validator: check signatures against PKI

### DIFF
--- a/cs/cstesting/cstesting.go
+++ b/cs/cstesting/cstesting.go
@@ -143,7 +143,7 @@ func SignLink(l *cs.Link) *cs.Link {
 // SignLinkWithKey signs the link with the provided private key.
 // The key must be an instance of ed25519.PrivateKey
 func SignLinkWithKey(l *cs.Link, priv ed25519.PrivateKey) *cs.Link {
-	pub := priv[32:]
+	pub := priv.Public().(ed25519.PublicKey)
 	payloadPath := "[state, meta]"
 	payload, _ := jmespath.Search(payloadPath, l)
 	payloadBytes, _ := cj.Marshal(payload)

--- a/cs/cstesting/cstesting.go
+++ b/cs/cstesting/cstesting.go
@@ -140,6 +140,24 @@ func SignLink(l *cs.Link) *cs.Link {
 	return l
 }
 
+// SignLinkWithKey signs the link with the provided private key.
+// The key must be an instance of ed25519.PrivateKey
+func SignLinkWithKey(l *cs.Link, priv ed25519.PrivateKey) *cs.Link {
+	pub := priv[32:]
+	payloadPath := "[state, meta]"
+	payload, _ := jmespath.Search(payloadPath, l)
+	payloadBytes, _ := cj.Marshal(payload)
+	sigBytes, _ := priv.Sign(crand.Reader, payloadBytes, crypto.Hash(0))
+	sig := cs.Signature{
+		Type:      "ed25519",
+		PublicKey: base64.StdEncoding.EncodeToString(pub),
+		Signature: base64.StdEncoding.EncodeToString(sigBytes),
+		Payload:   payloadPath,
+	}
+	l.Signatures = append(l.Signatures, &sig)
+	return l
+}
+
 // Clone clones a link.
 func Clone(l *cs.Link) *cs.Link {
 	var clone cs.Link

--- a/tmpop/tmpop.go
+++ b/tmpop/tmpop.go
@@ -173,12 +173,11 @@ func (t *TMPop) BeginBlock(req abci.RequestBeginBlock) abci.ResponseBeginBlock {
 	// TODO: we don't need to re-load the file for each block, it's expensive.
 	// We should improve this and only reload when a config update was committed.
 	if t.config.ValidatorFilename != "" {
-		cfg, err := validator.LoadConfig(t.config.ValidatorFilename)
+		validators, err := validator.LoadConfig(t.config.ValidatorFilename)
 		if err != nil {
 			log.Warnf("Could not load validator configuration: %s", err.Error())
-		} else {
-			t.state.validator = validator.NewMultiValidator(cfg)
 		}
+		t.state.validator = validator.NewMultiValidator(validators)
 	}
 
 	t.state.previousAppHash = types.NewBytes32FromBytes(t.currentHeader.AppHash)

--- a/tmstore/testdata/rules.json
+++ b/tmstore/testdata/rules.json
@@ -4,7 +4,7 @@
       "name": "Alice Van den Budenmayer",
       "roles": ["employee"]
     },
-    "TESTKEY2": {
+    "hmxvE+c9PwGUSEVZQ10RPaTP5SkuTR60pJ+Bhwqih48=": {
       "name": "Bob Wagner",
       "roles": ["manager", "it"]
     }

--- a/tmstore/testdata/rules.json
+++ b/tmstore/testdata/rules.json
@@ -1,15 +1,29 @@
 {
-  "testProcess": [
-    {
-      "type": "init",
-      "schema": {
-        "type": "object",
-        "properties": {
-          "string": {
-            "type": "string"
+  "pki": {
+    "TESTKEY1": {
+      "name": "Alice Van den Budenmayer",
+      "roles": ["employee"]
+    },
+    "TESTKEY2": {
+      "name": "Bob Wagner",
+      "roles": ["manager", "it"]
+    }
+  },
+  "validators": {
+    "testProcess": [
+      {
+        "id": "testProcess-schema",
+        "type": "init",
+        "signatures": ["it"],
+        "schema": {
+          "type": "object",
+          "properties": {
+            "string": {
+              "type": "string"
+            }
           }
         }
       }
-    }
-  ]
+    ]
+  }
 }

--- a/tmstore/tmstore_test.go
+++ b/tmstore/tmstore_test.go
@@ -15,6 +15,7 @@
 package tmstore
 
 import (
+	"encoding/base64"
 	"net/http"
 	"testing"
 
@@ -23,6 +24,8 @@ import (
 	"github.com/stratumn/sdk/store"
 	"github.com/stratumn/sdk/store/storetestcases"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/ed25519"
 )
 
 var (
@@ -38,13 +41,65 @@ func TestTMStore(t *testing.T) {
 
 func newTestTMStore() (store.Adapter, error) {
 	tmstore = NewTestClient()
-	tmstore.RetryStartWebsocket(DefaultWsRetryInterval)
+	err := tmstore.RetryStartWebsocket(DefaultWsRetryInterval)
+	if err != nil {
+		return nil, err
+	}
 
 	return tmstore, nil
 }
 
 func resetTMPop(_ store.Adapter) {
 	ResetNode()
+}
+
+// TestValidation tests custom validation rules
+func TestValidation(t *testing.T) {
+	tmstore, err := newTestTMStore()
+	require.NoError(t, err)
+
+	t.Run("Validation succeeds", func(t *testing.T) {
+		l := cstesting.RandomLink()
+		l.Meta["process"] = "testProcess"
+		l.Meta["action"] = "init"
+		l.State["string"] = "test"
+
+		privBytes, _ := base64.StdEncoding.DecodeString("3t39DaJp54JXnBuBR31K889hqAFNms3V5U5cWqaY5VmGbG8T5z0/AZRIRVlDXRE9pM/lKS5NHrSkn4GHCqKHjw==")
+		ITPrivateKey := ed25519.PrivateKey(privBytes)
+		l = cstesting.SignLinkWithKey(l, ITPrivateKey)
+
+		_, err = tmstore.CreateLink(l)
+		assert.NoError(t, err, "CreateLink() failed")
+	})
+
+	t.Run("Schema validation failed", func(t *testing.T) {
+		l := cstesting.RandomLink()
+		l.Meta["process"] = "testProcess"
+		l.Meta["action"] = "init"
+		l.State["string"] = 42
+
+		_, err = tmstore.CreateLink(l)
+		assert.Error(t, err, "A validation error is expected")
+
+		errHTTP, ok := err.(jsonhttp.ErrHTTP)
+		assert.True(t, ok, "Invalid error received: want ErrHTTP")
+		assert.Equal(t, http.StatusBadRequest, errHTTP.Status())
+	})
+
+	t.Run("Signature validation failed", func(t *testing.T) {
+		l := cstesting.RandomLink()
+		l = cstesting.SignLink(l)
+		l.Meta["process"] = "testProcess"
+		l.Meta["action"] = "init"
+		l.State["string"] = "test"
+
+		_, err = tmstore.CreateLink(l)
+		assert.Error(t, err, "A validation error is expected")
+
+		errHTTP, ok := err.(jsonhttp.ErrHTTP)
+		assert.True(t, ok, "Invalid error received: want ErrHTTP")
+		assert.Equal(t, http.StatusBadRequest, errHTTP.Status())
+	})
 }
 
 // TestWebSocket tests how the web socket with Tendermint behaves
@@ -73,39 +128,5 @@ func TestWebSocket(t *testing.T) {
 	t.Run("Stop already stopped websocket", func(t *testing.T) {
 		err := tmstore.StopWebsocket()
 		assert.NoError(t, err)
-	})
-}
-
-// TestValidation tests custom validation rules
-func TestValidation(t *testing.T) {
-	tmstore, err := newTestTMStore()
-	assert.NoError(t, err)
-
-	t.Run("Schema validation failed", func(t *testing.T) {
-		l := cstesting.RandomLink()
-		l.Meta["process"] = "testProcess"
-		l.Meta["action"] = "init"
-		l.State["string"] = 42
-
-		_, err = tmstore.CreateLink(l)
-		assert.Error(t, err, "A validation error is expected")
-
-		errHTTP, ok := err.(jsonhttp.ErrHTTP)
-		assert.True(t, ok, "Invalid error received: want ErrHTTP")
-		assert.Equal(t, http.StatusBadRequest, errHTTP.Status())
-	})
-
-	t.Run("Signature validation failed", func(t *testing.T) {
-		l := cstesting.RandomLink()
-		l.Meta["process"] = "testProcess"
-		l.Meta["action"] = "init"
-		l.State["string"] = "test"
-
-		_, err = tmstore.CreateLink(l)
-		assert.Error(t, err, "A validation error is expected")
-
-		errHTTP, ok := err.(jsonhttp.ErrHTTP)
-		assert.True(t, ok, "Invalid error received: want ErrHTTP")
-		assert.Equal(t, http.StatusBadRequest, errHTTP.Status())
 	})
 }

--- a/tmstore/tmstore_test.go
+++ b/tmstore/tmstore_test.go
@@ -81,15 +81,31 @@ func TestValidation(t *testing.T) {
 	tmstore, err := newTestTMStore()
 	assert.NoError(t, err)
 
-	l := cstesting.RandomLink()
-	l.Meta["process"] = "testProcess"
-	l.Meta["action"] = "init"
-	l.State["string"] = 42
+	t.Run("Schema validation failed", func(t *testing.T) {
+		l := cstesting.RandomLink()
+		l.Meta["process"] = "testProcess"
+		l.Meta["action"] = "init"
+		l.State["string"] = 42
 
-	_, err = tmstore.CreateLink(l)
-	assert.Error(t, err, "A validation error is expected")
+		_, err = tmstore.CreateLink(l)
+		assert.Error(t, err, "A validation error is expected")
 
-	errHTTP, ok := err.(jsonhttp.ErrHTTP)
-	assert.True(t, ok, "Invalid error received: want ErrHTTP")
-	assert.Equal(t, http.StatusBadRequest, errHTTP.Status())
+		errHTTP, ok := err.(jsonhttp.ErrHTTP)
+		assert.True(t, ok, "Invalid error received: want ErrHTTP")
+		assert.Equal(t, http.StatusBadRequest, errHTTP.Status())
+	})
+
+	t.Run("Signature validation failed", func(t *testing.T) {
+		l := cstesting.RandomLink()
+		l.Meta["process"] = "testProcess"
+		l.Meta["action"] = "init"
+		l.State["string"] = "test"
+
+		_, err = tmstore.CreateLink(l)
+		assert.Error(t, err, "A validation error is expected")
+
+		errHTTP, ok := err.(jsonhttp.ErrHTTP)
+		assert.True(t, ok, "Invalid error received: want ErrHTTP")
+		assert.Equal(t, http.StatusBadRequest, errHTTP.Status())
+	})
 }

--- a/validator/baseconfig.go
+++ b/validator/baseconfig.go
@@ -50,7 +50,7 @@ func newValidatorBaseConfig(process, id, linkType string) (*validatorBaseConfig,
 	if len(linkType) == 0 {
 		return nil, ErrMissingLinkType
 	}
-	return &validatorBaseConfig{Process: process, LinkType: linkType}, nil
+	return &validatorBaseConfig{Process: process, LinkType: linkType, ID: id}, nil
 }
 
 // shouldValidate returns true if the link matches the validator's process

--- a/validator/baseconfig.go
+++ b/validator/baseconfig.go
@@ -22,21 +22,29 @@ import (
 )
 
 var (
-	// ErrMissingProcess is returned when the process name is missing for schema validation.
-	ErrMissingProcess = errors.New("schema validation requires a process")
+	// ErrMissingProcess is returned when the process name is missing for validation.
+	ErrMissingProcess = errors.New("validator requires a process")
 
-	// ErrMissingLinkType is returned when the link type is missing for schema validation.
-	ErrMissingLinkType = errors.New("schema validation requires a link type")
+	// ErrMissingLinkType is returned when the link type is missing for validation.
+	ErrMissingLinkType = errors.New("validator requires a link type")
+
+	// ErrMissingIdentifier is returned when the link identifier is missing for validation.
+	ErrMissingIdentifier = errors.New("validator requires an identifier")
 )
 
 type validatorBaseConfig struct {
+	ID       string
 	Process  string
 	LinkType string
 }
 
-func newValidatorBaseConfig(process, linkType string) (*validatorBaseConfig, error) {
+func newValidatorBaseConfig(process, id, linkType string) (*validatorBaseConfig, error) {
 	if len(process) == 0 {
 		return nil, ErrMissingProcess
+	}
+
+	if len(id) == 0 {
+		return nil, ErrMissingIdentifier
 	}
 
 	if len(linkType) == 0 {

--- a/validator/baseconfig.go
+++ b/validator/baseconfig.go
@@ -53,10 +53,10 @@ func newValidatorBaseConfig(process, id, linkType string) (*validatorBaseConfig,
 	return &validatorBaseConfig{Process: process, LinkType: linkType, ID: id}, nil
 }
 
-// shouldValidate returns true if the link matches the validator's process
+// ShouldValidate returns true if the link matches the validator's process
 // and type. Otherwise the link is considered valid because this validator
 // doesn't apply to it.
-func (bv *validatorBaseConfig) shouldValidate(link *cs.Link) bool {
+func (bv *validatorBaseConfig) ShouldValidate(link *cs.Link) bool {
 	linkProcess, ok := link.Meta["process"].(string)
 	if !ok {
 		log.Debug("No process found in link %v", link)

--- a/validator/baseconfig_test.go
+++ b/validator/baseconfig_test.go
@@ -17,17 +17,20 @@ package validator
 import (
 	"testing"
 
+	"github.com/stratumn/sdk/cs"
+	"github.com/stratumn/sdk/cs/cstesting"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestBaseConfig(t *testing.T) {
 	process := "p1"
-	linkType := "sell"
+	action := "sell"
 
 	type testCaseCfg struct {
 		id            string
 		process       string
-		linkType      string
+		action        string
 		schema        []byte
 		valid         bool
 		expectedError error
@@ -36,26 +39,26 @@ func TestBaseConfig(t *testing.T) {
 	testCases := []testCaseCfg{{
 		id:            "missing-process",
 		process:       "",
-		linkType:      linkType,
+		action:        action,
 		valid:         false,
 		expectedError: ErrMissingProcess,
 	}, {
 		id:            "",
 		process:       process,
-		linkType:      linkType,
+		action:        action,
 		valid:         false,
 		expectedError: ErrMissingIdentifier,
 	}, {
 		id:            "missing-link-type",
 		process:       process,
-		linkType:      "",
+		action:        "",
 		valid:         false,
 		expectedError: ErrMissingLinkType,
 	}, {
-		id:       "valid-config",
-		process:  process,
-		linkType: linkType,
-		valid:    true,
+		id:      "valid-config",
+		process: process,
+		action:  action,
+		valid:   true,
 	},
 	}
 
@@ -64,7 +67,7 @@ func TestBaseConfig(t *testing.T) {
 			cfg, err := newValidatorBaseConfig(
 				tt.process,
 				tt.id,
-				tt.linkType,
+				tt.action,
 			)
 
 			if tt.valid {
@@ -77,6 +80,80 @@ func TestBaseConfig(t *testing.T) {
 					assert.EqualError(t, err, tt.expectedError.Error())
 				}
 			}
+		})
+	}
+}
+
+func TestBaseConfig_ShouldValidate(t *testing.T) {
+	process := "p1"
+	action := "sell"
+	cfg, err := newValidatorBaseConfig(
+		process,
+		"test",
+		action,
+	)
+	require.NoError(t, err)
+
+	createValidLink := func() *cs.Link {
+		l := cstesting.RandomLink()
+		l.Meta["process"] = process
+		l.Meta["action"] = action
+		return cstesting.SignLink(l)
+	}
+	type testCase struct {
+		name           string
+		link           func() *cs.Link
+		shouldValidate bool
+	}
+
+	testCases := []testCase{
+		{
+			name:           "valid-link",
+			shouldValidate: true,
+			link:           createValidLink,
+		},
+		{
+			name:           "no-process",
+			shouldValidate: false,
+			link: func() *cs.Link {
+				l := createValidLink()
+				delete(l.Meta, "process")
+				return l
+			},
+		},
+		{
+			name:           "process-no-match",
+			shouldValidate: false,
+			link: func() *cs.Link {
+				l := createValidLink()
+				l.Meta["process"] = "test"
+				return l
+			},
+		},
+		{
+			name:           "no-action",
+			shouldValidate: false,
+			link: func() *cs.Link {
+				l := createValidLink()
+				delete(l.Meta, "action")
+				return l
+			},
+		},
+		{
+			name:           "action-no-match",
+			shouldValidate: false,
+			link: func() *cs.Link {
+				l := createValidLink()
+				l.Meta["action"] = "test"
+				return l
+			},
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			res := cfg.ShouldValidate(tt.link())
+			assert.Equal(t, tt.shouldValidate, res)
 		})
 	}
 }

--- a/validator/baseconfig_test.go
+++ b/validator/baseconfig_test.go
@@ -25,7 +25,7 @@ func TestBaseConfig(t *testing.T) {
 	linkType := "sell"
 
 	type testCaseCfg struct {
-		name          string
+		id            string
 		process       string
 		linkType      string
 		schema        []byte
@@ -34,19 +34,25 @@ func TestBaseConfig(t *testing.T) {
 	}
 
 	testCases := []testCaseCfg{{
-		name:          "missing-process",
+		id:            "missing-process",
 		process:       "",
 		linkType:      linkType,
 		valid:         false,
 		expectedError: ErrMissingProcess,
 	}, {
-		name:          "missing-link-type",
+		id:            "",
+		process:       process,
+		linkType:      linkType,
+		valid:         false,
+		expectedError: ErrMissingIdentifier,
+	}, {}, {
+		id:            "missing-link-type",
 		process:       process,
 		linkType:      "",
 		valid:         false,
 		expectedError: ErrMissingLinkType,
 	}, {
-		name:     "valid-config",
+		id:       "valid-config",
 		process:  process,
 		linkType: linkType,
 		valid:    true,
@@ -54,9 +60,10 @@ func TestBaseConfig(t *testing.T) {
 	}
 
 	for _, tt := range testCases {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.id, func(t *testing.T) {
 			cfg, err := newValidatorBaseConfig(
 				tt.process,
+				tt.id,
 				tt.linkType,
 			)
 
@@ -69,7 +76,6 @@ func TestBaseConfig(t *testing.T) {
 				if tt.expectedError != nil {
 					assert.EqualError(t, err, tt.expectedError.Error())
 				}
-
 			}
 		})
 	}

--- a/validator/baseconfig_test.go
+++ b/validator/baseconfig_test.go
@@ -45,7 +45,7 @@ func TestBaseConfig(t *testing.T) {
 		linkType:      linkType,
 		valid:         false,
 		expectedError: ErrMissingIdentifier,
-	}, {}, {
+	}, {
 		id:            "missing-link-type",
 		process:       process,
 		linkType:      "",

--- a/validator/configloader.go
+++ b/validator/configloader.go
@@ -28,7 +28,7 @@ var (
 	ErrInvalidValidator = errors.New("a validator requires a JSON schema or a signature criteria to be valid")
 
 	// ErrBadPublicKey is returned when a public key is empty or not base64-encoded
-	ErrBadPublicKey = errors.New("Public key must be a non-null base64 encoded string")
+	ErrBadPublicKey = errors.New("public key must be a non null base64 encoded string")
 
 	// ErrNoPKI is returned when rules.json doesn't contain a `pki` field
 	ErrNoPKI = errors.New("rules.json needs a 'pki' field to list authorized public keys")
@@ -40,7 +40,7 @@ type rulesSchema struct {
 }
 
 // LoadConfig loads the validators configuration from a json file.
-// The configuration returned can be then be used in NewMultiValidator().
+// The configuration returned can then be used in NewMultiValidator().
 func LoadConfig(path string) (*MultiValidatorConfig, error) {
 	f, err := os.Open(path)
 	if err != nil {

--- a/validator/configloader.go
+++ b/validator/configloader.go
@@ -41,7 +41,7 @@ type rulesSchema struct {
 
 // LoadConfig loads the validators configuration from a json file.
 // The configuration returned can then be used in NewMultiValidator().
-func LoadConfig(path string) ([]ChildValidator, error) {
+func LoadConfig(path string) ([]Validator, error) {
 	f, err := os.Open(path)
 	if err != nil {
 		return nil, errors.WithStack(err)
@@ -93,14 +93,14 @@ type jsonValidatorData []struct {
 	Schema     *json.RawMessage `json:"schema"`
 }
 
-func loadValidatorsConfig(data json.RawMessage, pki *PKI) ([]ChildValidator, error) {
+func loadValidatorsConfig(data json.RawMessage, pki *PKI) ([]Validator, error) {
 	var jsonStruct map[string]jsonValidatorData
 	err := json.Unmarshal(data, &jsonStruct)
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
 
-	var validators []ChildValidator
+	var validators []Validator
 	for process, jsonSchemaData := range jsonStruct {
 		for _, val := range jsonSchemaData {
 			if val.ID == "" {

--- a/validator/configloader.go
+++ b/validator/configloader.go
@@ -125,11 +125,11 @@ func loadValidatorsConfig(data json.RawMessage, pki *PKI) (*MultiValidatorConfig
 			}
 
 			if len(val.Signatures) > 0 {
-				cfg, err := newSignatureValidatorConfig(process, val.ID, val.Type, val.Signatures, pki)
+				cfg, err := newPkiValidatorConfig(process, val.ID, val.Type, val.Signatures, pki)
 				if err != nil {
 					return nil, err
 				}
-				validatorConfig.SignatureConfigs = append(validatorConfig.SignatureConfigs, cfg)
+				validatorConfig.PkiConfigs = append(validatorConfig.PkiConfigs, cfg)
 			}
 
 			if val.Schema != nil {

--- a/validator/configloader_test.go
+++ b/validator/configloader_test.go
@@ -219,6 +219,35 @@ func TestLoadConfig_Success(t *testing.T) {
 		require.Len(t, cfg.PkiConfigs, 0)
 	})
 
+	t.Run("No PKI", func(T *testing.T) {
+
+		const validJSONSig = `
+		{
+			"validators": {
+			    "test": [
+				{
+				    "id": "initSigned",
+				    "type": "init",
+				    "schema": {
+					"type": "object"
+				    }
+				}
+			    ]
+			}
+		    }
+		`
+
+		testFile := createTMPFile(t, validJSONSig)
+		defer os.Remove(testFile)
+		cfg, err := LoadConfig(testFile)
+
+		require.NoError(t, err, "LoadConfig()")
+		assert.NotNil(t, cfg)
+
+		assert.Len(t, cfg.SchemaConfigs, 1)
+		require.Len(t, cfg.PkiConfigs, 0)
+	})
+
 }
 
 func TestLoadValidators_Error(t *testing.T) {
@@ -338,8 +367,16 @@ func TestLoadPKI_Error(t *testing.T) {
 	t.Run("No PKI", func(T *testing.T) {
 		const noPKIConfig = `
 		{
-			"validators": {}
-		}
+			"validators": {
+				"auction": [
+				    {
+					"id": "missingType",
+					"type": "action",	
+					"signatures": ["test"]
+				    }
+				]
+			    }
+		    }
 		`
 		testFile := createTMPFile(t, noPKIConfig)
 		defer os.Remove(testFile)

--- a/validator/configloader_test.go
+++ b/validator/configloader_test.go
@@ -129,7 +129,16 @@ func TestLoadConfig_Success(t *testing.T) {
 		assert.NoError(t, err, "LoadConfig()")
 		assert.NotNil(t, validators)
 
-		assert.Len(t, validators, 5)
+		var schemaValidatorCount, pkiValidatorCount int
+		for _, v := range validators {
+			if _, ok := v.(*pkiValidator); ok {
+				pkiValidatorCount++
+			} else if _, ok := v.(*schemaValidator); ok {
+				schemaValidatorCount++
+			}
+		}
+		assert.Equal(t, 3, schemaValidatorCount)
+		assert.Equal(t, 2, pkiValidatorCount)
 	})
 
 	t.Run("Null signatures", func(T *testing.T) {
@@ -171,7 +180,9 @@ func TestLoadConfig_Success(t *testing.T) {
 		require.NoError(t, err, "LoadConfig()")
 		assert.NotNil(t, validators)
 
-		assert.Len(t, validators, 1)
+		require.Len(t, validators, 1)
+		_, ok := validators[0].(*schemaValidator)
+		assert.True(t, ok)
 	})
 
 	t.Run("Empty signatures", func(T *testing.T) {
@@ -213,7 +224,9 @@ func TestLoadConfig_Success(t *testing.T) {
 		require.NoError(t, err, "LoadConfig()")
 		assert.NotNil(t, validators)
 
-		assert.Len(t, validators, 1)
+		require.Len(t, validators, 1)
+		_, ok := validators[0].(*schemaValidator)
+		assert.True(t, ok)
 	})
 
 	t.Run("No PKI", func(T *testing.T) {
@@ -242,6 +255,9 @@ func TestLoadConfig_Success(t *testing.T) {
 		assert.NotNil(t, validators)
 
 		assert.Len(t, validators, 1)
+		require.Len(t, validators, 1)
+		_, ok := validators[0].(*schemaValidator)
+		assert.True(t, ok)
 	})
 
 }

--- a/validator/configloader_test.go
+++ b/validator/configloader_test.go
@@ -405,7 +405,7 @@ func TestLoadPKI_Error(t *testing.T) {
 		cfg, err := LoadConfig(testFile)
 
 		assert.Nil(t, cfg)
-		assert.EqualError(t, err, "Error while parsing PKI: Public key must be a non-null base64 encoded string")
+		assert.EqualError(t, err, "Error while parsing PKI: public key must be a non null base64 encoded string")
 	})
 }
 

--- a/validator/configloader_test.go
+++ b/validator/configloader_test.go
@@ -130,7 +130,7 @@ func TestLoadConfig_Success(t *testing.T) {
 		assert.NotNil(t, cfg)
 
 		assert.Len(t, cfg.SchemaConfigs, 3)
-		assert.Len(t, cfg.SignatureConfigs, 2)
+		assert.Len(t, cfg.PkiConfigs, 2)
 	})
 
 	t.Run("Null signatures", func(T *testing.T) {
@@ -173,7 +173,7 @@ func TestLoadConfig_Success(t *testing.T) {
 		assert.NotNil(t, cfg)
 
 		assert.Len(t, cfg.SchemaConfigs, 1)
-		require.Len(t, cfg.SignatureConfigs, 0)
+		require.Len(t, cfg.PkiConfigs, 0)
 	})
 
 	t.Run("Empty signatures", func(T *testing.T) {
@@ -216,7 +216,7 @@ func TestLoadConfig_Success(t *testing.T) {
 		assert.NotNil(t, cfg)
 
 		assert.Len(t, cfg.SchemaConfigs, 1)
-		require.Len(t, cfg.SignatureConfigs, 0)
+		require.Len(t, cfg.PkiConfigs, 0)
 	})
 
 }

--- a/validator/configloader_test.go
+++ b/validator/configloader_test.go
@@ -124,13 +124,12 @@ func TestLoadConfig_Success(t *testing.T) {
 
 		testFile := createTMPFile(t, validJSONConfig)
 		defer os.Remove(testFile)
-		cfg, err := LoadConfig(testFile)
+		validators, err := LoadConfig(testFile)
 
 		assert.NoError(t, err, "LoadConfig()")
-		assert.NotNil(t, cfg)
+		assert.NotNil(t, validators)
 
-		assert.Len(t, cfg.SchemaConfigs, 3)
-		assert.Len(t, cfg.PkiConfigs, 2)
+		assert.Len(t, validators, 5)
 	})
 
 	t.Run("Null signatures", func(T *testing.T) {
@@ -167,13 +166,12 @@ func TestLoadConfig_Success(t *testing.T) {
 
 		testFile := createTMPFile(t, validJSONSig)
 		defer os.Remove(testFile)
-		cfg, err := LoadConfig(testFile)
+		validators, err := LoadConfig(testFile)
 
 		require.NoError(t, err, "LoadConfig()")
-		assert.NotNil(t, cfg)
+		assert.NotNil(t, validators)
 
-		assert.Len(t, cfg.SchemaConfigs, 1)
-		require.Len(t, cfg.PkiConfigs, 0)
+		assert.Len(t, validators, 1)
 	})
 
 	t.Run("Empty signatures", func(T *testing.T) {
@@ -210,13 +208,12 @@ func TestLoadConfig_Success(t *testing.T) {
 
 		testFile := createTMPFile(t, validJSONSig)
 		defer os.Remove(testFile)
-		cfg, err := LoadConfig(testFile)
+		validators, err := LoadConfig(testFile)
 
 		require.NoError(t, err, "LoadConfig()")
-		assert.NotNil(t, cfg)
+		assert.NotNil(t, validators)
 
-		assert.Len(t, cfg.SchemaConfigs, 1)
-		require.Len(t, cfg.PkiConfigs, 0)
+		assert.Len(t, validators, 1)
 	})
 
 	t.Run("No PKI", func(T *testing.T) {
@@ -239,13 +236,12 @@ func TestLoadConfig_Success(t *testing.T) {
 
 		testFile := createTMPFile(t, validJSONSig)
 		defer os.Remove(testFile)
-		cfg, err := LoadConfig(testFile)
+		validators, err := LoadConfig(testFile)
 
 		require.NoError(t, err, "LoadConfig()")
-		assert.NotNil(t, cfg)
+		assert.NotNil(t, validators)
 
-		assert.Len(t, cfg.SchemaConfigs, 1)
-		require.Len(t, cfg.PkiConfigs, 0)
+		assert.Len(t, validators, 1)
 	})
 
 }
@@ -266,9 +262,9 @@ func TestLoadValidators_Error(t *testing.T) {
 		    }
 		`
 		testFile := createTMPFile(t, invalidValidatorConfig)
-		cfg, err := LoadConfig(testFile)
+		validators, err := LoadConfig(testFile)
 
-		assert.Nil(t, cfg)
+		assert.Nil(t, validators)
 		assert.EqualError(t, err, ErrInvalidValidator.Error())
 	})
 
@@ -299,9 +295,9 @@ func TestLoadValidators_Error(t *testing.T) {
 		`
 		testFile := createTMPFile(t, invalidValidatorConfig)
 		defer os.Remove(testFile)
-		cfg, err := LoadConfig(testFile)
+		validators, err := LoadConfig(testFile)
 
-		assert.Nil(t, cfg)
+		assert.Nil(t, validators)
 		assert.EqualError(t, err, ErrMissingIdentifier.Error())
 	})
 
@@ -332,9 +328,9 @@ func TestLoadValidators_Error(t *testing.T) {
 		`
 		testFile := createTMPFile(t, invalidValidatorConfig)
 		defer os.Remove(testFile)
-		cfg, err := LoadConfig(testFile)
+		validators, err := LoadConfig(testFile)
 
-		assert.Nil(t, cfg)
+		assert.Nil(t, validators)
 		assert.EqualError(t, err, ErrMissingLinkType.Error())
 	})
 
@@ -355,9 +351,9 @@ func TestLoadValidators_Error(t *testing.T) {
 		`
 		testFile := createTMPFile(t, invalidValidatorConfig)
 		defer os.Remove(testFile)
-		cfg, err := LoadConfig(testFile)
+		validators, err := LoadConfig(testFile)
 
-		assert.Nil(t, cfg)
+		assert.Nil(t, validators)
 		assert.Error(t, err)
 	})
 }
@@ -380,9 +376,9 @@ func TestLoadPKI_Error(t *testing.T) {
 		`
 		testFile := createTMPFile(t, noPKIConfig)
 		defer os.Remove(testFile)
-		cfg, err := LoadConfig(testFile)
+		validators, err := LoadConfig(testFile)
 
-		assert.Nil(t, cfg)
+		assert.Nil(t, validators)
 		assert.EqualError(t, err, "rules.json needs a 'pki' field to list authorized public keys")
 	})
 
@@ -402,9 +398,9 @@ func TestLoadPKI_Error(t *testing.T) {
 		`
 		testFile := createTMPFile(t, invalidPKIConfig)
 		defer os.Remove(testFile)
-		cfg, err := LoadConfig(testFile)
+		validators, err := LoadConfig(testFile)
 
-		assert.Nil(t, cfg)
+		assert.Nil(t, validators)
 		assert.EqualError(t, err, "Error while parsing PKI: public key must be a non null base64 encoded string")
 	})
 }

--- a/validator/multivalidator.go
+++ b/validator/multivalidator.go
@@ -25,16 +25,20 @@ import (
 )
 
 type multiValidator struct {
-	validators []ChildValidator
+	validators []Validator
 }
 
 // NewMultiValidator creates a validator that will simply be a collection
 // of single-purpose validators.
-// The configuration should be loaded from a JSON file via validator.LoadConfig().
-func NewMultiValidator(validators []ChildValidator) Validator {
+// The slice of validators should be loaded from a JSON file via validator.LoadConfig().
+func NewMultiValidator(validators []Validator) Validator {
 	return &multiValidator{
 		validators: append(validators, newSignatureValidator()),
 	}
+}
+
+func (v multiValidator) ShouldValidate(link *cs.Link) bool {
+	return true
 }
 
 func (v multiValidator) Hash() (*types.Bytes32, error) {
@@ -46,7 +50,7 @@ func (v multiValidator) Hash() (*types.Bytes32, error) {
 	return &validationsHash, nil
 }
 
-func (v multiValidator) matchValidators(l *cs.Link) (linkValidators []ChildValidator) {
+func (v multiValidator) matchValidators(l *cs.Link) (linkValidators []Validator) {
 	for _, child := range v.validators {
 		if child.ShouldValidate(l) {
 			linkValidators = append(linkValidators, child)

--- a/validator/multivalidator_test.go
+++ b/validator/multivalidator_test.go
@@ -22,18 +22,19 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestMultiValidator_New(t *testing.T) {
-	mv := NewMultiValidator(&MultiValidatorConfig{
-		SchemaConfigs: []*schemaValidatorConfig{
-			&schemaValidatorConfig{},
-			&schemaValidatorConfig{},
-		},
-		PkiConfigs: []*pkiValidatorConfig{
-			&pkiValidatorConfig{},
-		},
-	})
+const validJSON = `
+{
+	"pki": {
+	},
+	"validators": {
+	}
+    }
+`
 
-	assert.Len(t, mv.(*multiValidator).validators, 3)
+func TestMultiValidator_New(t *testing.T) {
+	mv := NewMultiValidator([]ChildValidator{})
+
+	assert.Len(t, mv.(*multiValidator).validators, 1)
 }
 
 func TestMultiValidator_Hash(t *testing.T) {
@@ -41,69 +42,66 @@ func TestMultiValidator_Hash(t *testing.T) {
 	baseConfig2 := &validatorBaseConfig{Process: "p2"}
 
 	t.Run("With schema validator", func(t *testing.T) {
-		mv1 := NewMultiValidator(&MultiValidatorConfig{
-			SchemaConfigs: []*schemaValidatorConfig{
-				&schemaValidatorConfig{
-					validatorBaseConfig: baseConfig1,
-				}},
-		})
+		mv1 := NewMultiValidator([]ChildValidator{
+			schemaValidator{
+				Config: baseConfig1,
+			}},
+		)
 
 		h1, err := mv1.Hash()
 		assert.NoError(t, err)
 		assert.NotNil(t, h1)
 
-		mv2 := NewMultiValidator(&MultiValidatorConfig{
-			SchemaConfigs: []*schemaValidatorConfig{
-				&schemaValidatorConfig{
-					validatorBaseConfig: baseConfig1,
-				}},
-		})
+		mv2 := NewMultiValidator([]ChildValidator{
+			&schemaValidator{
+				Config: baseConfig1,
+			}},
+		)
 
 		h2, err := mv2.Hash()
 		assert.NoError(t, err)
 		assert.EqualValues(t, h1, h2)
 
-		mv3 := NewMultiValidator(&MultiValidatorConfig{
-			SchemaConfigs: []*schemaValidatorConfig{
-				&schemaValidatorConfig{
-					validatorBaseConfig: baseConfig2,
-				}},
-		})
+		mv3 := NewMultiValidator([]ChildValidator{
+			schemaValidator{
+				Config: baseConfig2,
+			}},
+		)
 
 		h3, err := mv3.Hash()
 		assert.NoError(t, err)
 		assert.False(t, h1.Equals(h3))
 	})
 
-	t.Run("With signature validator", func(t *testing.T) {
-		mv1 := NewMultiValidator(&MultiValidatorConfig{
-			PkiConfigs: []*pkiValidatorConfig{
-				&pkiValidatorConfig{
-					validatorBaseConfig: baseConfig1,
-				}},
-		})
+	t.Run("With pki validator", func(t *testing.T) {
+		mv1 := NewMultiValidator([]ChildValidator{
+			&pkiValidator{
+				Config: baseConfig1,
+			},
+		},
+		)
 
 		h1, err := mv1.Hash()
 		assert.NoError(t, err)
 		assert.NotNil(t, h1)
 
-		mv2 := NewMultiValidator(&MultiValidatorConfig{
-			PkiConfigs: []*pkiValidatorConfig{
-				&pkiValidatorConfig{
-					validatorBaseConfig: baseConfig1,
-				}},
-		})
+		mv2 := NewMultiValidator([]ChildValidator{
+			&pkiValidator{
+				Config: baseConfig1,
+			},
+		},
+		)
 
 		h2, err := mv2.Hash()
 		assert.NoError(t, err)
 		assert.EqualValues(t, h1, h2)
 
-		mv3 := NewMultiValidator(&MultiValidatorConfig{
-			PkiConfigs: []*pkiValidatorConfig{
-				&pkiValidatorConfig{
-					validatorBaseConfig: baseConfig2,
-				}},
-		})
+		mv3 := NewMultiValidator([]ChildValidator{
+			&pkiValidator{
+				Config: baseConfig2,
+			},
+		},
+		)
 
 		h3, err := mv3.Hash()
 		assert.NoError(t, err)
@@ -125,16 +123,21 @@ const testMessageSchema = `
 }`
 
 func TestMultiValidator_Validate(t *testing.T) {
-	svCfg1, _ := newSchemaValidatorConfig("p", "id1", "a1", []byte(testMessageSchema))
-	svCfg2, _ := newSchemaValidatorConfig("p", "id2", "a2", []byte(testMessageSchema))
+	baseConfig1, _ := newValidatorBaseConfig("p", "id1", "a1")
+	baseConfig2, _ := newValidatorBaseConfig("p", "id2", "a2")
+	baseConfig3, _ := newValidatorBaseConfig("p", "id3", "a1")
+	baseConfig4, _ := newValidatorBaseConfig("p", "id4", "a2")
 
-	sigVCfg1, _ := newPkiValidatorConfig("p", "id3", "a1", []string{}, &PKI{})
-	sigVCfg2, _ := newPkiValidatorConfig("p", "id4", "a2", []string{}, &PKI{})
+	svCfg1, _ := newSchemaValidator(baseConfig1, []byte(testMessageSchema))
+	svCfg2, _ := newSchemaValidator(baseConfig2, []byte(testMessageSchema))
 
-	mv := NewMultiValidator(&MultiValidatorConfig{
-		SchemaConfigs: []*schemaValidatorConfig{svCfg1, svCfg2},
-		PkiConfigs:    []*pkiValidatorConfig{sigVCfg1, sigVCfg2},
-	})
+	sigVCfg1 := newPkiValidator(baseConfig3, []string{}, &PKI{})
+	sigVCfg2 := newPkiValidator(baseConfig4, []string{}, &PKI{})
+
+	// append a signatureValidator in the validators to reproduce NewMultiValidator behaviour
+	mv := multiValidator{
+		validators: []ChildValidator{svCfg1, svCfg2, sigVCfg1, sigVCfg2, newSignatureValidator()},
+	}
 
 	t.Run("Validate succeeds when all children succeed", func(t *testing.T) {
 		l := cstesting.RandomLink()

--- a/validator/multivalidator_test.go
+++ b/validator/multivalidator_test.go
@@ -128,8 +128,8 @@ func TestMultiValidator_Validate(t *testing.T) {
 	svCfg1, _ := newSchemaValidatorConfig("p", "id1", "a1", []byte(testMessageSchema))
 	svCfg2, _ := newSchemaValidatorConfig("p", "id2", "a2", []byte(testMessageSchema))
 
-	sigVCfg1, _ := newSignatureValidatorConfig("p", "id3", "a1", &PKI{})
-	sigVCfg2, _ := newSignatureValidatorConfig("p", "id4", "a2", &PKI{})
+	sigVCfg1, _ := newSignatureValidatorConfig("p", "id3", "a1", []string{}, &PKI{})
+	sigVCfg2, _ := newSignatureValidatorConfig("p", "id4", "a2", []string{}, &PKI{})
 
 	mv := NewMultiValidator(&MultiValidatorConfig{
 		SchemaConfigs:    []*schemaValidatorConfig{svCfg1, svCfg2},

--- a/validator/multivalidator_test.go
+++ b/validator/multivalidator_test.go
@@ -32,7 +32,7 @@ const validJSON = `
 `
 
 func TestMultiValidator_New(t *testing.T) {
-	mv := NewMultiValidator([]ChildValidator{})
+	mv := NewMultiValidator([]Validator{})
 
 	assert.Len(t, mv.(*multiValidator).validators, 1)
 }
@@ -42,7 +42,7 @@ func TestMultiValidator_Hash(t *testing.T) {
 	baseConfig2 := &validatorBaseConfig{Process: "p2"}
 
 	t.Run("With schema validator", func(t *testing.T) {
-		mv1 := NewMultiValidator([]ChildValidator{
+		mv1 := NewMultiValidator([]Validator{
 			schemaValidator{
 				Config: baseConfig1,
 			}},
@@ -52,7 +52,7 @@ func TestMultiValidator_Hash(t *testing.T) {
 		assert.NoError(t, err)
 		assert.NotNil(t, h1)
 
-		mv2 := NewMultiValidator([]ChildValidator{
+		mv2 := NewMultiValidator([]Validator{
 			&schemaValidator{
 				Config: baseConfig1,
 			}},
@@ -62,7 +62,7 @@ func TestMultiValidator_Hash(t *testing.T) {
 		assert.NoError(t, err)
 		assert.EqualValues(t, h1, h2)
 
-		mv3 := NewMultiValidator([]ChildValidator{
+		mv3 := NewMultiValidator([]Validator{
 			schemaValidator{
 				Config: baseConfig2,
 			}},
@@ -74,7 +74,7 @@ func TestMultiValidator_Hash(t *testing.T) {
 	})
 
 	t.Run("With pki validator", func(t *testing.T) {
-		mv1 := NewMultiValidator([]ChildValidator{
+		mv1 := NewMultiValidator([]Validator{
 			&pkiValidator{
 				Config: baseConfig1,
 			},
@@ -85,7 +85,7 @@ func TestMultiValidator_Hash(t *testing.T) {
 		assert.NoError(t, err)
 		assert.NotNil(t, h1)
 
-		mv2 := NewMultiValidator([]ChildValidator{
+		mv2 := NewMultiValidator([]Validator{
 			&pkiValidator{
 				Config: baseConfig1,
 			},
@@ -96,7 +96,7 @@ func TestMultiValidator_Hash(t *testing.T) {
 		assert.NoError(t, err)
 		assert.EqualValues(t, h1, h2)
 
-		mv3 := NewMultiValidator([]ChildValidator{
+		mv3 := NewMultiValidator([]Validator{
 			&pkiValidator{
 				Config: baseConfig2,
 			},
@@ -136,7 +136,7 @@ func TestMultiValidator_Validate(t *testing.T) {
 
 	// append a signatureValidator in the validators to reproduce NewMultiValidator behaviour
 	mv := multiValidator{
-		validators: []ChildValidator{svCfg1, svCfg2, sigVCfg1, sigVCfg2, newSignatureValidator()},
+		validators: []Validator{svCfg1, svCfg2, sigVCfg1, sigVCfg2, newSignatureValidator()},
 	}
 
 	t.Run("Validate succeeds when all children succeed", func(t *testing.T) {

--- a/validator/multivalidator_test.go
+++ b/validator/multivalidator_test.go
@@ -125,11 +125,11 @@ const testMessageSchema = `
 }`
 
 func TestMultiValidator_Validate(t *testing.T) {
-	svCfg1, _ := newSchemaValidatorConfig("p", "a1", []byte(testMessageSchema))
-	svCfg2, _ := newSchemaValidatorConfig("p", "a2", []byte(testMessageSchema))
+	svCfg1, _ := newSchemaValidatorConfig("p", "id1", "a1", []byte(testMessageSchema))
+	svCfg2, _ := newSchemaValidatorConfig("p", "id2", "a2", []byte(testMessageSchema))
 
-	sigVCfg1, _ := newSignatureValidatorConfig("p", "a1")
-	sigVCfg2, _ := newSignatureValidatorConfig("p", "a2")
+	sigVCfg1, _ := newSignatureValidatorConfig("p", "id3", "a1", &PKI{})
+	sigVCfg2, _ := newSignatureValidatorConfig("p", "id4", "a2", &PKI{})
 
 	mv := NewMultiValidator(&MultiValidatorConfig{
 		SchemaConfigs:    []*schemaValidatorConfig{svCfg1, svCfg2},

--- a/validator/pki.go
+++ b/validator/pki.go
@@ -15,12 +15,15 @@
 package validator
 
 import (
+	"crypto/sha256"
 	"strings"
 
+	cj "github.com/gibson042/canonicaljson-go"
 	"github.com/pkg/errors"
 
 	"github.com/stratumn/sdk/cs"
 	"github.com/stratumn/sdk/store"
+	"github.com/stratumn/sdk/types"
 )
 
 // PKI maps a public key to an identity.
@@ -62,7 +65,7 @@ type pkiValidator struct {
 	pki                *PKI
 }
 
-func newPkiValidator(baseConfig *validatorBaseConfig, required []string, pki *PKI) ChildValidator {
+func newPkiValidator(baseConfig *validatorBaseConfig, required []string, pki *PKI) Validator {
 	return &pkiValidator{
 		Config:             baseConfig,
 		requiredSignatures: required,
@@ -70,6 +73,14 @@ func newPkiValidator(baseConfig *validatorBaseConfig, required []string, pki *PK
 	}
 }
 
+func (pv pkiValidator) Hash() (*types.Bytes32, error) {
+	b, err := cj.Marshal(pv)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	validationsHash := types.Bytes32(sha256.Sum256(b))
+	return &validationsHash, nil
+}
 func (pv pkiValidator) ShouldValidate(link *cs.Link) bool {
 	return pv.Config.ShouldValidate(link)
 }

--- a/validator/pki.go
+++ b/validator/pki.go
@@ -1,0 +1,102 @@
+// Copyright 2017 Stratumn SAS. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validator
+
+import (
+	"strings"
+
+	"github.com/pkg/errors"
+
+	"github.com/stratumn/sdk/cs"
+	"github.com/stratumn/sdk/store"
+)
+
+// pkiValidatorConfig contains everything a pkiValidator needs to
+// validate links.
+type pkiValidatorConfig struct {
+	*validatorBaseConfig
+	requiredSignatures []string
+	pki                *PKI
+}
+
+// newSignatureValidatorConfig creates a pkiValidatorConfig for a given process and type.
+func newPkiValidatorConfig(process, id, linkType string, required []string, pki *PKI) (*pkiValidatorConfig, error) {
+	baseConfig, err := newValidatorBaseConfig(process, id, linkType)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+
+	return &pkiValidatorConfig{
+		validatorBaseConfig: baseConfig,
+		requiredSignatures:  required,
+		pki:                 pki,
+	}, nil
+}
+
+// pkiValidator validates the json signature of a link's state.
+type pkiValidator struct {
+	*pkiValidatorConfig
+}
+
+func newPkiValidator(config *pkiValidatorConfig) childValidator {
+	return &pkiValidator{config}
+}
+
+func (pv pkiValidator) matchRequirement(requirement, publicKey string) bool {
+	if requirement == publicKey {
+		return true
+	}
+
+	identity, ok := (*pv.pki)[publicKey]
+	if !ok {
+		return false
+	}
+	if strings.EqualFold(identity.Name, requirement) {
+		return true
+	}
+	for _, role := range identity.Roles {
+		if strings.EqualFold(role, requirement) {
+			return true
+		}
+	}
+	return false
+}
+
+func (pv pkiValidator) isSignatureRequired(publicKey string) bool {
+	for _, required := range pv.requiredSignatures {
+		if pv.matchRequirement(required, publicKey) {
+			return true
+		}
+	}
+	return false
+}
+
+// Validate checks that the provided dignatures match the required ones.
+// a requirement can either be : a public key, a name defined in PKI, a role defined in PKI
+func (pv pkiValidator) Validate(_ store.SegmentReader, link *cs.Link) error {
+	for _, required := range pv.requiredSignatures {
+		fulfilled := false
+		for _, sig := range link.Signatures {
+			if pv.matchRequirement(required, sig.PublicKey) {
+				fulfilled = true
+				break
+			}
+		}
+		if !fulfilled {
+			return errors.Errorf("Missing signatory for validator %s: signature from %s is required", pv.ID, required)
+		}
+	}
+	return nil
+}

--- a/validator/pki.go
+++ b/validator/pki.go
@@ -55,35 +55,23 @@ type Identity struct {
 	Roles []string
 }
 
-// pkiValidatorConfig contains everything a pkiValidator needs to
-// validate links.
-type pkiValidatorConfig struct {
-	*validatorBaseConfig
+// pkiValidator validates the json signature of a link's state.
+type pkiValidator struct {
+	Config             *validatorBaseConfig
 	requiredSignatures []string
 	pki                *PKI
 }
 
-// newSignatureValidatorConfig creates a pkiValidatorConfig for a given process and type.
-func newPkiValidatorConfig(process, id, linkType string, required []string, pki *PKI) (*pkiValidatorConfig, error) {
-	baseConfig, err := newValidatorBaseConfig(process, id, linkType)
-	if err != nil {
-		return nil, errors.WithStack(err)
+func newPkiValidator(baseConfig *validatorBaseConfig, required []string, pki *PKI) ChildValidator {
+	return &pkiValidator{
+		Config:             baseConfig,
+		requiredSignatures: required,
+		pki:                pki,
 	}
-
-	return &pkiValidatorConfig{
-		validatorBaseConfig: baseConfig,
-		requiredSignatures:  required,
-		pki:                 pki,
-	}, nil
 }
 
-// pkiValidator validates the json signature of a link's state.
-type pkiValidator struct {
-	*pkiValidatorConfig
-}
-
-func newPkiValidator(config *pkiValidatorConfig) childValidator {
-	return &pkiValidator{config}
+func (pv pkiValidator) ShouldValidate(link *cs.Link) bool {
+	return pv.Config.ShouldValidate(link)
 }
 
 func (pv pkiValidator) isSignatureRequired(publicKey string) bool {
@@ -107,7 +95,7 @@ func (pv pkiValidator) Validate(_ store.SegmentReader, link *cs.Link) error {
 			}
 		}
 		if !fulfilled {
-			return errors.Errorf("Missing signatory for validator %s: signature from %s is required", pv.ID, required)
+			return errors.Errorf("Missing signatory for validator %s: signature from %s is required", pv.Config.ID, required)
 		}
 	}
 	return nil

--- a/validator/pki_test.go
+++ b/validator/pki_test.go
@@ -1,0 +1,142 @@
+// Copyright 2017 Stratumn SAS. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validator
+
+import (
+	"crypto/rand"
+	"testing"
+
+	"github.com/stratumn/sdk/cs"
+	"github.com/stratumn/sdk/cs/cstesting"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/ed25519"
+)
+
+func TestPKIValidator(t *testing.T) {
+	process := "p1"
+	action := "test"
+
+	createValidLink := func() *cs.Link {
+		l := cstesting.RandomLink()
+		l.Meta["process"] = process
+		l.Meta["action"] = action
+		return cstesting.SignLink(l)
+	}
+
+	createValidLinkWithKey := func(priv ed25519.PrivateKey) *cs.Link {
+		l := cstesting.RandomLink()
+		l.Meta["process"] = process
+		l.Meta["action"] = action
+		return cstesting.SignLinkWithKey(l, priv)
+	}
+
+	_, priv1, _ := ed25519.GenerateKey(rand.Reader)
+	_, priv2, _ := ed25519.GenerateKey(rand.Reader)
+	link1 := createValidLinkWithKey(priv1)
+	link2 := createValidLinkWithKey(priv2)
+
+	pki := &PKI{
+		link1.Signatures[0].PublicKey: &Identity{
+			Name:  "Alice Van den Budenmayer",
+			Roles: []string{"employee"},
+		},
+		link2.Signatures[0].PublicKey: &Identity{
+			Name:  "Bob Wagner",
+			Roles: []string{"manager", "it"},
+		},
+	}
+
+	type testCase struct {
+		name               string
+		link               func() *cs.Link
+		valid              bool
+		err                string
+		requiredSignatures []string
+	}
+
+	testCases := []testCase{
+		{
+			name:  "valid-link",
+			valid: true,
+			link:  createValidLink,
+		},
+		{
+			name:  "required-signature-pubkey",
+			valid: true,
+			link: func() *cs.Link {
+				return link1
+			},
+			requiredSignatures: []string{link1.Signatures[0].PublicKey},
+		},
+		{
+			name:  "required-signature-name",
+			valid: true,
+			link: func() *cs.Link {
+				return link1
+			},
+			requiredSignatures: []string{"alice van den budenmayer"},
+		},
+		{
+			name:  "required-signature-role",
+			valid: true,
+			link: func() *cs.Link {
+				return link1
+			},
+			requiredSignatures: []string{"employee"},
+		},
+		{
+			name:  "required-signature-extra",
+			valid: true,
+			link: func() *cs.Link {
+				tmpLink := *link1
+				return cstesting.SignLink(&tmpLink)
+			},
+			requiredSignatures: []string{"employee"},
+		},
+		{
+			name:  "required-signature-multi",
+			valid: true,
+			link: func() *cs.Link {
+				tmpLink := *link1
+				return cstesting.SignLinkWithKey(&tmpLink, priv2)
+			},
+			requiredSignatures: []string{"employee", "it", "bob wagner"},
+		},
+		{
+			name:               "required-signature-fails",
+			valid:              false,
+			err:                "Missing signatory for validator required-signature-fails: signature from alice van den budenmayer is required",
+			link:               createValidLink,
+			requiredSignatures: []string{"alice van den budenmayer"},
+		},
+	}
+
+	for _, tt := range testCases {
+		cfg, err := newPkiValidatorConfig(process, tt.name, action, tt.requiredSignatures, pki)
+		require.NoError(t, err)
+		sv := newPkiValidator(cfg)
+
+		t.Run(tt.name, func(t *testing.T) {
+			err := sv.Validate(nil, tt.link())
+			if tt.valid {
+				assert.NoError(t, err)
+			} else {
+				assert.EqualError(t, err, tt.err)
+			}
+		})
+	}
+
+}

--- a/validator/pki_test.go
+++ b/validator/pki_test.go
@@ -125,9 +125,9 @@ func TestPKIValidator(t *testing.T) {
 	}
 
 	for _, tt := range testCases {
-		cfg, err := newPkiValidatorConfig(process, tt.name, action, tt.requiredSignatures, pki)
+		baseCfg, err := newValidatorBaseConfig(process, tt.name, action)
 		require.NoError(t, err)
-		sv := newPkiValidator(cfg)
+		sv := newPkiValidator(baseCfg, tt.requiredSignatures, pki)
 
 		t.Run(tt.name, func(t *testing.T) {
 			err := sv.Validate(nil, tt.link())

--- a/validator/schema.go
+++ b/validator/schema.go
@@ -55,16 +55,12 @@ type schemaValidator struct {
 	*schemaValidatorConfig
 }
 
-func newSchemaValidator(config *schemaValidatorConfig) validator {
+func newSchemaValidator(config *schemaValidatorConfig) childValidator {
 	return &schemaValidator{config}
 }
 
 // Validate validates the schema of a link's state.
 func (sv schemaValidator) Validate(_ store.SegmentReader, link *cs.Link) error {
-	if !sv.shouldValidate(link) {
-		return nil
-	}
-
 	stateBytes, err := json.Marshal(link.State)
 	if err != nil {
 		return errors.WithStack(err)

--- a/validator/schema.go
+++ b/validator/schema.go
@@ -25,38 +25,25 @@ import (
 	"github.com/xeipuuv/gojsonschema"
 )
 
-// schemaValidatorConfig contains everything a schemaValidator needs to
-// validate links.
-type schemaValidatorConfig struct {
-	*validatorBaseConfig
+// schemaValidator validates the json schema of a link's state.
+type schemaValidator struct {
+	Config *validatorBaseConfig
 	Schema *gojsonschema.Schema
 }
 
-// newSchemaValidatorConfig creates a schemaValidatorConfig for a given process and type.
-func newSchemaValidatorConfig(process, id, linkType string, schemaData []byte) (*schemaValidatorConfig, error) {
-	baseConfig, err := newValidatorBaseConfig(process, id, linkType)
-	if err != nil {
-		return nil, errors.WithStack(err)
-	}
-
+func newSchemaValidator(baseConfig *validatorBaseConfig, schemaData []byte) (ChildValidator, error) {
 	schema, err := gojsonschema.NewSchema(gojsonschema.NewBytesLoader(schemaData))
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
 
-	return &schemaValidatorConfig{
-		validatorBaseConfig: baseConfig,
-		Schema:              schema,
+	return &schemaValidator{
+		Config: baseConfig,
+		Schema: schema,
 	}, nil
 }
-
-// schemaValidator validates the json schema of a link's state.
-type schemaValidator struct {
-	*schemaValidatorConfig
-}
-
-func newSchemaValidator(config *schemaValidatorConfig) childValidator {
-	return &schemaValidator{config}
+func (sv schemaValidator) ShouldValidate(link *cs.Link) bool {
+	return sv.Config.ShouldValidate(link)
 }
 
 // Validate validates the schema of a link's state.

--- a/validator/schema.go
+++ b/validator/schema.go
@@ -52,16 +52,16 @@ func newSchemaValidatorConfig(process, id, linkType string, schemaData []byte) (
 
 // schemaValidator validates the json schema of a link's state.
 type schemaValidator struct {
-	config *schemaValidatorConfig
+	*schemaValidatorConfig
 }
 
 func newSchemaValidator(config *schemaValidatorConfig) validator {
-	return &schemaValidator{config: config}
+	return &schemaValidator{config}
 }
 
 // Validate validates the schema of a link's state.
 func (sv schemaValidator) Validate(_ store.SegmentReader, link *cs.Link) error {
-	if !sv.config.shouldValidate(link) {
+	if !sv.shouldValidate(link) {
 		return nil
 	}
 
@@ -71,7 +71,7 @@ func (sv schemaValidator) Validate(_ store.SegmentReader, link *cs.Link) error {
 	}
 
 	stateData := gojsonschema.NewBytesLoader(stateBytes)
-	result, err := sv.config.Schema.Validate(stateData)
+	result, err := sv.Schema.Validate(stateData)
 	if err != nil {
 		return errors.WithStack(err)
 	}

--- a/validator/schema.go
+++ b/validator/schema.go
@@ -33,8 +33,8 @@ type schemaValidatorConfig struct {
 }
 
 // newSchemaValidatorConfig creates a schemaValidatorConfig for a given process and type.
-func newSchemaValidatorConfig(process, linkType string, schemaData []byte) (*schemaValidatorConfig, error) {
-	baseConfig, err := newValidatorBaseConfig(process, linkType)
+func newSchemaValidatorConfig(process, id, linkType string, schemaData []byte) (*schemaValidatorConfig, error) {
+	baseConfig, err := newValidatorBaseConfig(process, id, linkType)
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}

--- a/validator/schema_test.go
+++ b/validator/schema_test.go
@@ -127,30 +127,6 @@ func TestSchemaValidator(t *testing.T) {
 	}
 
 	testCases := []testCase{{
-		name:  "process-not-matched",
-		valid: true,
-		link: func() *cs.Link {
-			l := createInvalidLink()
-			l.Meta["process"] = "p2"
-			return l
-		},
-	}, {
-		name:  "type-not-matched",
-		valid: true,
-		link: func() *cs.Link {
-			l := createInvalidLink()
-			l.Meta["action"] = "buy"
-			return l
-		},
-	}, {
-		name:  "missing-action",
-		valid: true,
-		link: func() *cs.Link {
-			l := createInvalidLink()
-			delete(l.Meta, "action")
-			return l
-		},
-	}, {
 		name:  "valid-link",
 		valid: true,
 		link:  createValidLink,

--- a/validator/schema_test.go
+++ b/validator/schema_test.go
@@ -78,6 +78,7 @@ func TestSchemaValidatorConfig(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg, err := newSchemaValidatorConfig(
 				tt.process,
+				tt.name,
 				tt.linkType,
 				tt.schema,
 			)
@@ -99,7 +100,7 @@ func TestSchemaValidatorConfig(t *testing.T) {
 
 func TestSchemaValidator(t *testing.T) {
 	schema := []byte(testSellSchema)
-	cfg, err := newSchemaValidatorConfig("p1", "sell", schema)
+	cfg, err := newSchemaValidatorConfig("p1", "id1", "sell", schema)
 	require.NoError(t, err)
 	sv := newSchemaValidator(cfg)
 

--- a/validator/schema_test.go
+++ b/validator/schema_test.go
@@ -76,18 +76,14 @@ func TestSchemaValidatorConfig(t *testing.T) {
 
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
-			cfg, err := newSchemaValidatorConfig(
-				tt.process,
-				tt.name,
-				tt.linkType,
-				tt.schema,
-			)
+			baseCfg, _ := newValidatorBaseConfig(process, tt.name, tt.linkType)
+			sv, err := newSchemaValidator(baseCfg, tt.schema)
 
 			if tt.valid {
-				assert.NotNil(t, cfg)
+				assert.NotNil(t, sv)
 				assert.NoError(t, err)
 			} else {
-				assert.Nil(t, cfg)
+				assert.Nil(t, sv)
 				assert.Error(t, err)
 				if tt.expectedError != nil {
 					assert.EqualError(t, err, tt.expectedError.Error())
@@ -100,9 +96,10 @@ func TestSchemaValidatorConfig(t *testing.T) {
 
 func TestSchemaValidator(t *testing.T) {
 	schema := []byte(testSellSchema)
-	cfg, err := newSchemaValidatorConfig("p1", "id1", "sell", schema)
+	baseCfg, err := newValidatorBaseConfig("p1", "id1", "sell")
 	require.NoError(t, err)
-	sv := newSchemaValidator(cfg)
+	sv, err := newSchemaValidator(baseCfg, schema)
+	require.NoError(t, err)
 
 	createValidLink := func() *cs.Link {
 		l := cstesting.RandomLink()

--- a/validator/signature.go
+++ b/validator/signature.go
@@ -16,7 +16,6 @@ package validator
 
 import (
 	"encoding/base64"
-	"strings"
 
 	cj "github.com/gibson042/canonicaljson-go"
 	jmespath "github.com/jmespath/go-jmespath"
@@ -39,23 +38,10 @@ var (
 // signatureValidatorConfig contains everything a signatureValidator needs to
 // validate links.
 type signatureValidatorConfig struct {
-	*validatorBaseConfig
-	requiredSignatures []string
-	pki                *PKI
 }
 
-// newSignatureValidatorConfig creates a signatureValidatorConfig for a given process and type.
-func newSignatureValidatorConfig(process, id, linkType string, required []string, pki *PKI) (*signatureValidatorConfig, error) {
-	baseConfig, err := newValidatorBaseConfig(process, id, linkType)
-	if err != nil {
-		return nil, errors.WithStack(err)
-	}
-
-	return &signatureValidatorConfig{
-		validatorBaseConfig: baseConfig,
-		requiredSignatures:  required,
-		pki:                 pki,
-	}, nil
+func (bv *signatureValidatorConfig) ShouldValidate(_ *cs.Link) bool {
+	return true
 }
 
 // signatureValidator validates the json signature of a link's state.
@@ -63,70 +49,12 @@ type signatureValidator struct {
 	*signatureValidatorConfig
 }
 
-func newSignatureValidator(config *signatureValidatorConfig) validator {
+func newSignatureValidator(config *signatureValidatorConfig) childValidator {
 	return &signatureValidator{config}
-}
-
-func (sv signatureValidator) matchRequirement(requirement, publicKey string) bool {
-	if requirement == publicKey {
-		return true
-	}
-
-	identity, ok := (*sv.pki)[publicKey]
-	if !ok {
-		return false
-	}
-	if strings.EqualFold(identity.Name, requirement) {
-		return true
-	}
-	for _, role := range identity.Roles {
-		if strings.EqualFold(role, requirement) {
-			return true
-		}
-	}
-	return false
-}
-
-func (sv signatureValidator) isSignatureRequired(publicKey string) bool {
-	for _, required := range sv.requiredSignatures {
-		if sv.matchRequirement(required, publicKey) {
-			return true
-		}
-	}
-	return false
-}
-
-// missingSignatory checks that the provided dignatures match the required ones.
-// a requirement can either be : a public key, a name defined in PKI, a role defined in PKI
-func (sv signatureValidator) missingSignatory(signatures cs.Signatures) error {
-	for _, required := range sv.requiredSignatures {
-		fulfilled := false
-		for _, sig := range signatures {
-			if sv.matchRequirement(required, sig.PublicKey) {
-				fulfilled = true
-				break
-			}
-		}
-		if !fulfilled {
-			return errors.Errorf("A signature from %s is required", required)
-		}
-	}
-	return nil
 }
 
 // Validate validates the signature of a link's state.
 func (sv signatureValidator) Validate(_ store.SegmentReader, link *cs.Link) error {
-	if !sv.shouldValidate(link) {
-		return nil
-	}
-
-	if len(link.Signatures) == 0 {
-		return ErrMissingSignature
-	}
-
-	if err := sv.missingSignatory(link.Signatures); err != nil {
-		return errors.Wrapf(err, "Missing signatory for validator %s", sv.ID)
-	}
 
 	for _, sig := range link.Signatures {
 

--- a/validator/signature.go
+++ b/validator/signature.go
@@ -35,22 +35,16 @@ var (
 	ErrEmptyPayload = errors.New("JMESPATH query does not match any link data")
 )
 
-// signatureValidatorConfig contains everything a signatureValidator needs to
-// validate links.
-type signatureValidatorConfig struct {
-}
-
-func (bv *signatureValidatorConfig) ShouldValidate(_ *cs.Link) bool {
-	return true
-}
-
 // signatureValidator validates the json signature of a link's state.
 type signatureValidator struct {
-	*signatureValidatorConfig
 }
 
-func newSignatureValidator(config *signatureValidatorConfig) childValidator {
-	return &signatureValidator{config}
+func newSignatureValidator() ChildValidator {
+	return &signatureValidator{}
+}
+
+func (sv *signatureValidator) ShouldValidate(link *cs.Link) bool {
+	return true
 }
 
 // Validate validates the signature of a link's state.

--- a/validator/signature.go
+++ b/validator/signature.go
@@ -39,16 +39,17 @@ var (
 // validate links.
 type signatureValidatorConfig struct {
 	*validatorBaseConfig
+	pki *PKI
 }
 
 // newSignatureValidatorConfig creates a signatureValidatorConfig for a given process and type.
-func newSignatureValidatorConfig(process, linkType string) (*signatureValidatorConfig, error) {
-	baseConfig, err := newValidatorBaseConfig(process, linkType)
+func newSignatureValidatorConfig(process, id, linkType string, pki *PKI) (*signatureValidatorConfig, error) {
+	baseConfig, err := newValidatorBaseConfig(process, id, linkType)
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
 
-	return &signatureValidatorConfig{baseConfig}, nil
+	return &signatureValidatorConfig{validatorBaseConfig: baseConfig, pki: pki}, nil
 }
 
 // signatureValidator validates the json signature of a link's state.

--- a/validator/signature.go
+++ b/validator/signature.go
@@ -15,6 +15,7 @@
 package validator
 
 import (
+	"crypto/sha256"
 	"encoding/base64"
 
 	cj "github.com/gibson042/canonicaljson-go"
@@ -23,6 +24,7 @@ import (
 
 	"github.com/stratumn/sdk/cs"
 	"github.com/stratumn/sdk/store"
+	"github.com/stratumn/sdk/types"
 	"github.com/stratumn/sdk/validator/signature"
 )
 
@@ -39,11 +41,20 @@ var (
 type signatureValidator struct {
 }
 
-func newSignatureValidator() ChildValidator {
+func newSignatureValidator() Validator {
 	return &signatureValidator{}
 }
 
-func (sv *signatureValidator) ShouldValidate(link *cs.Link) bool {
+func (sv signatureValidator) Hash() (*types.Bytes32, error) {
+	b, err := cj.Marshal(sv)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	validationsHash := types.Bytes32(sha256.Sum256(b))
+	return &validationsHash, nil
+}
+
+func (sv signatureValidator) ShouldValidate(link *cs.Link) bool {
 	return true
 }
 

--- a/validator/signature_test.go
+++ b/validator/signature_test.go
@@ -26,8 +26,9 @@ import (
 
 func TestSignatureValidator(t *testing.T) {
 	process := "p1"
+	id := "id1"
 	action := "test"
-	cfg, err := newSignatureValidatorConfig(process, action)
+	cfg, err := newSignatureValidatorConfig(process, id, action, &PKI{})
 	require.NoError(t, err)
 	sv := newSignatureValidator(cfg)
 

--- a/validator/signature_test.go
+++ b/validator/signature_test.go
@@ -91,7 +91,7 @@ func TestSignatureValidator(t *testing.T) {
 	}
 
 	for _, tt := range testCases {
-		sv := newSignatureValidator(&signatureValidatorConfig{})
+		sv := newSignatureValidator()
 
 		t.Run(tt.name, func(t *testing.T) {
 			err := sv.Validate(nil, tt.link())

--- a/validator/signature_test.go
+++ b/validator/signature_test.go
@@ -15,6 +15,7 @@
 package validator
 
 import (
+	"crypto/rand"
 	"testing"
 
 	"github.com/stratumn/sdk/cs"
@@ -22,15 +23,12 @@ import (
 	"github.com/stratumn/sdk/validator/signature"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/ed25519"
 )
 
 func TestSignatureValidator(t *testing.T) {
 	process := "p1"
-	id := "id1"
 	action := "test"
-	cfg, err := newSignatureValidatorConfig(process, id, action, &PKI{})
-	require.NoError(t, err)
-	sv := newSignatureValidator(cfg)
 
 	createValidLink := func() *cs.Link {
 		l := cstesting.RandomLink()
@@ -39,11 +37,35 @@ func TestSignatureValidator(t *testing.T) {
 		return cstesting.SignLink(l)
 	}
 
+	createValidLinkWithKey := func(priv ed25519.PrivateKey) *cs.Link {
+		l := cstesting.RandomLink()
+		l.Meta["process"] = process
+		l.Meta["action"] = action
+		return cstesting.SignLinkWithKey(l, priv)
+	}
+
+	_, priv1, _ := ed25519.GenerateKey(rand.Reader)
+	_, priv2, _ := ed25519.GenerateKey(rand.Reader)
+	link1 := createValidLinkWithKey(priv1)
+	link2 := createValidLinkWithKey(priv2)
+
+	pki := &PKI{
+		link1.Signatures[0].PublicKey: &Identity{
+			Name:  "Alice Van den Budenmayer",
+			Roles: []string{"employee"},
+		},
+		link2.Signatures[0].PublicKey: &Identity{
+			Name:  "Bob Wagner",
+			Roles: []string{"manager", "it"},
+		},
+	}
+
 	type testCase struct {
-		name  string
-		link  func() *cs.Link
-		valid bool
-		err   string
+		name               string
+		link               func() *cs.Link
+		valid              bool
+		err                string
+		requiredSignatures []string
 	}
 
 	testCases := []testCase{
@@ -120,9 +142,62 @@ func TestSignatureValidator(t *testing.T) {
 				return l
 			},
 		},
+		{
+			name:  "required-signature-pubkey",
+			valid: true,
+			link: func() *cs.Link {
+				return link1
+			},
+			requiredSignatures: []string{link1.Signatures[0].PublicKey},
+		},
+		{
+			name:  "required-signature-name",
+			valid: true,
+			link: func() *cs.Link {
+				return link1
+			},
+			requiredSignatures: []string{"alice van den budenmayer"},
+		},
+		{
+			name:  "required-signature-role",
+			valid: true,
+			link: func() *cs.Link {
+				return link1
+			},
+			requiredSignatures: []string{"employee"},
+		},
+		{
+			name:  "required-signature-extra",
+			valid: true,
+			link: func() *cs.Link {
+				tmpLink := *link1
+				return cstesting.SignLink(&tmpLink)
+			},
+			requiredSignatures: []string{"employee"},
+		},
+		{
+			name:  "required-signature-multi",
+			valid: true,
+			link: func() *cs.Link {
+				tmpLink := *link1
+				return cstesting.SignLinkWithKey(&tmpLink, priv2)
+			},
+			requiredSignatures: []string{"employee", "it", "bob wagner"},
+		},
+		{
+			name:               "required-signature-fails",
+			valid:              false,
+			err:                "Missing signatory for validator required-signature-fails: A signature from alice van den budenmayer is required",
+			link:               createValidLink,
+			requiredSignatures: []string{"alice van den budenmayer"},
+		},
 	}
 
 	for _, tt := range testCases {
+		cfg, err := newSignatureValidatorConfig(process, tt.name, action, tt.requiredSignatures, pki)
+		require.NoError(t, err)
+		sv := newSignatureValidator(cfg)
+
 		t.Run(tt.name, func(t *testing.T) {
 			err := sv.Validate(nil, tt.link())
 			if tt.valid {

--- a/validator/validator.go
+++ b/validator/validator.go
@@ -32,6 +32,14 @@ type validator interface {
 	Validate(store.SegmentReader, *cs.Link) error
 }
 
+// childValidator defines an interface that have to be implemented by a custom validator (eg: signature, schema, state...)
+type childValidator interface {
+	validator
+
+	// ShouldValidate returns a boolean whether the link should be checked
+	ShouldValidate(*cs.Link) bool
+}
+
 // Validator defines a validator that has an internal state, identified by
 // its hash.
 type Validator interface {

--- a/validator/validator.go
+++ b/validator/validator.go
@@ -25,25 +25,15 @@ const (
 	DefaultFilename = "/data/validation/rules.json"
 )
 
-// validator defines the interface with single Validate() method
-type validator interface {
-	// Validate runs validations on a link and returns an error
-	// if the link is invalid.
-	Validate(store.SegmentReader, *cs.Link) error
-}
-
-// ChildValidator defines an interface that have to be implemented by a custom validator (eg: signature, schema, state...)
-type ChildValidator interface {
-	validator
-
-	// ShouldValidate returns a boolean whether the link should be checked
-	ShouldValidate(*cs.Link) bool
-}
-
 // Validator defines a validator that has an internal state, identified by
 // its hash.
 type Validator interface {
-	validator
+	// Validate runs validations on a link and returns an error
+	// if the link is invalid.
+	Validate(store.SegmentReader, *cs.Link) error
+
+	// ShouldValidate returns a boolean whether the link should be checked
+	ShouldValidate(*cs.Link) bool
 
 	// Hash returns the hash of the validator's state.
 	// It can be used to know which set of validations were applied

--- a/validator/validator.go
+++ b/validator/validator.go
@@ -32,8 +32,8 @@ type validator interface {
 	Validate(store.SegmentReader, *cs.Link) error
 }
 
-// childValidator defines an interface that have to be implemented by a custom validator (eg: signature, schema, state...)
-type childValidator interface {
+// ChildValidator defines an interface that have to be implemented by a custom validator (eg: signature, schema, state...)
+type ChildValidator interface {
 	validator
 
 	// ShouldValidate returns a boolean whether the link should be checked

--- a/validator/validator_test.go
+++ b/validator/validator_test.go
@@ -27,71 +27,98 @@ import (
 
 const validJSONConfig = `
 {
-  "auction": [
-    {
-      "type": "init",
-      "schema": {
-        "type": "object",
-        "properties": {
-          "seller": {
-            "type": "string"
-          },
-          "lot": {
-            "type": "string"
-          },
-          "initialPrice": {
-            "type": "integer",
-            "minimum": 0
-          }
-        },
-        "required": [
-          "seller",
-          "lot",
-          "initialPrice"
-        ]
-      }
-    },
-    {
-      "type": "bid",
-      "schema": {
-        "type": "object",
-        "properties": {
-          "buyer": {
-            "type": "string"
-          },
-          "bidPrice": {
-            "type": "integer",
-            "minimum": 0
-          }
-        },
-        "required": [
-          "buyer",
-          "bidPrice"
-        ]
-      }
+	"pki": {
+	    "TESTKEY1": {
+		"name": "Alice Van den Budenmayer",
+		"roles": [
+		    "employee"
+		]
+	    },
+	    "TESTKEY2": {
+		"name": "Bob Wagner",
+		"roles": [
+		    "manager",
+		    "it"
+		]
+	    }
+	},
+	"validators": {
+	    "auction": [
+		{
+		    "id": "initFormat",	
+		    "type": "init",
+		    "signatures": true,
+		    "schema": {
+			"type": "object",
+			"properties": {
+			    "seller": {
+				"type": "string"
+			    },
+			    "lot": {
+				"type": "string"
+			    },
+			    "initialPrice": {
+				"type": "integer",
+				"minimum": 0
+			    }
+			},
+			"required": [
+			    "seller",
+			    "lot",
+			    "initialPrice"
+			]
+		    }
+		},
+		{
+    		    "id": "bidFormat",	
+	  	    "type": "bid",
+		    "schema": {
+			"type": "object",
+			"properties": {
+			    "buyer": {
+				"type": "string"
+			    },
+			    "bidPrice": {
+				"type": "integer",
+				"minimum": 0
+			    }
+			},
+			"required": [
+			    "buyer",
+			    "bidPrice"
+			]
+		    }
+		}
+	    ],
+	    "chat": [
+		{
+		    "id": "messageFormat",	
+		    "type": "message",
+		    "signatures": false,
+		    "schema": {
+			"type": "object",
+			"properties": {
+			    "to": {
+				"type": "string"
+			    },
+			    "content": {
+				"type": "string"
+			    }
+			},
+			"required": [
+			    "to",
+			    "content"
+			]
+		    }
+		},
+		{
+		    "id": "initSigned",
+		    "type": "init",
+		    "signatures": true
+		}
+	    ]
+	}
     }
-  ],
-  "chat": [
-    {
-      "type": "message",
-      "schema": {
-        "type": "object",
-        "properties": {
-          "to": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "to",
-          "content"
-        ]   
-      }
-    }
-  ]
-}
 `
 
 type testCase struct {

--- a/validator/validator_test.go
+++ b/validator/validator_test.go
@@ -185,11 +185,10 @@ func TestValidator(t *testing.T) {
 	_, err = tmpfile.WriteString(validJSONConfig)
 	require.NoError(t, err, "tmpfile.WriteString()")
 
-	cfg, err := validator.LoadConfig(tmpfile.Name())
+	children, err := validator.LoadConfig(tmpfile.Name())
 	assert.NoError(t, err, "validator.LoadConfig()")
 
-	v := validator.NewMultiValidator(cfg)
-	assert.NotNil(t, v, "validator.NewMultiValidator()")
+	v := validator.NewMultiValidator(children)
 
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {

--- a/validator/validator_test.go
+++ b/validator/validator_test.go
@@ -47,7 +47,7 @@ const validJSONConfig = `
 		{
 		    "id": "initFormat",	
 		    "type": "init",
-		    "signatures": true,
+		    "signatures": ["Alice Van den Budenmayer"],
 		    "schema": {
 			"type": "object",
 			"properties": {
@@ -94,7 +94,7 @@ const validJSONConfig = `
 		{
 		    "id": "messageFormat",	
 		    "type": "message",
-		    "signatures": false,
+		    "signatures": null,
 		    "schema": {
 			"type": "object",
 			"properties": {
@@ -114,7 +114,7 @@ const validJSONConfig = `
 		{
 		    "id": "initSigned",
 		    "type": "init",
-		    "signatures": true
+		    "signatures": ["manager"]
 		}
 	    ]
 	}


### PR DESCRIPTION
`rules.json` format was updated:
 - a `pki` property must be specified: it defines a list of "identities" linked to public keys. It allows signature validation rules to be more user-friendly (one can require signatures by name, role or public key)
 - an identifier `id` must be specified in a validator
 - the `signatures` property of a validator is now a slice of strings. In the example below, the `init` action of the `testProcess` process (the first segment) needs to be signed by both `TESTKEY1` (alice) and `TESTKEY2` (bob). If this property is omitted or empty, no signature is required. Nevertheless, it there are signatures in `link.Signatures`, they will still be verified and an error will be thrown if an error is encountered.
```json
{
  "pki": {
    "TESTKEY1": {
      "name": "Alice Van den Budenmayer",
      "roles": ["employee"]
    },
    "TESTKEY2": {
      "name": "Bob Wagner",
      "roles": ["manager", "it"]
    }
  },
  "validators": {
    "testProcess": [
      {
        "id": "testProcess-schema",
        "type": "init",
        "signatures": ["manager", "alice van den bundemayer"],
        "schema": {
          "type": "object",
          "properties": {
            "string": {
              "type": "string"
            }
          }
        }
      }
    ]
  }
}
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stratumn/sdk/339)
<!-- Reviewable:end -->
